### PR TITLE
Fix errors encountered when building with LLVM 3.7.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
     "Path to LLVM source code. Not necessary if using an installed LLVM.")
   set(MSILCJIT_PATH_TO_LLVM_BUILD "" CACHE PATH
     "Path to the directory where LLVM was built or installed.")
+  set(MSILCJIT_PATH_TO_CORECLR_BUILD "" CACHE PATH
+    "Path to the directory containing the CoreCLR drop to build against.")
 
   if( MSILCJIT_PATH_TO_LLVM_SOURCE )
     if( NOT EXISTS "${MSILCJIT_PATH_TO_LLVM_SOURCE}/cmake/config-ix.cmake" )
@@ -318,6 +320,12 @@ add_definitions( -D_GNU_SOURCE )
 add_definitions( -DFEATURE_CORECLR )
 
 if (UNIX)
+  if (NOT EXISTS "${MSILCJIT_PATH_TO_CORECLR_BUILD}/libcoreclr.so")
+    message(FATAL_ERROR "Please set MSILCJIT_PATH_TO_CORECLR_BUILD to a directory containing a CoreCLR build.")
+  else()
+    link_directories("${MSILCJIT_PATH_TO_CORECLR_BUILD}")
+  endif()
+
   add_definitions( -DPLATFORM_UNIX )
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/Pal/Rt)
 else()

--- a/include/Jit/MSILCJit.h
+++ b/include/Jit/MSILCJit.h
@@ -34,7 +34,8 @@ class MSILCJitContext {
 public:
   MSILCJitContext(MSILCJitPerThreadState *State);
   ~MSILCJitContext();
-  llvm::Module *getModuleForMethod(CORINFO_METHOD_INFO *MethodInfo);
+  std::unique_ptr<llvm::Module>
+  getModuleForMethod(CORINFO_METHOD_INFO *MethodInfo);
   void outputDebugMethodName();
   inline BYTE getILByte() { return *((BYTE *&)ILCursor)++; }
   inline DWORD getILDword() { return *((UNALIGNED DWORD *&)ILCursor)++; }

--- a/include/Pal/MSILCPal.h
+++ b/include/Pal/MSILCPal.h
@@ -149,7 +149,7 @@
 #define __inout_ecount(count)
 #define __deref_inout_ecount(count)
 
-#ifdef  __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
@@ -160,16 +160,18 @@ extern "C" {
 #define EXTERN_C
 #endif // __cplusplus
 
-#if defined(__llvm__)
-#define DECLSPEC_ALIGN(x)   __declspec(align(x))
-#else
-#define DECLSPEC_ALIGN(x) 
-#endif
-
 #define _ASSERTE assert
 #define __assume(x) (void)0
 
 #define UNALIGNED
+
+#if !defined(_HOST_X86_)
+#define __stdcall
+#endif
+
+#if defined(__GNUC__)
+#define __cdecl __attribute__((cdecl))
+#endif
 
 #define PALIMPORT EXTERN_C
 #define PALAPI __stdcall
@@ -371,7 +373,7 @@ namespace StaticContract
 {
     struct ScanThrowMarkerStandard
     {
-        __declspec(noinline) ScanThrowMarkerStandard()
+        __attribute__((noinline)) ScanThrowMarkerStandard()
         {
             METHOD_CANNOT_BE_FOLDED_DEBUG;
             STATIC_CONTRACT_THROWS;
@@ -382,7 +384,7 @@ namespace StaticContract
 
     struct ScanThrowMarkerTerminal
     {
-        __declspec(noinline) ScanThrowMarkerTerminal()
+        __attribute__((noinline)) ScanThrowMarkerTerminal()
         {
             METHOD_CANNOT_BE_FOLDED_DEBUG;
         }
@@ -390,7 +392,7 @@ namespace StaticContract
 
     struct ScanThrowMarkerIgnore
     {
-        __declspec(noinline) ScanThrowMarkerIgnore()
+        __attribute__((noinline)) ScanThrowMarkerIgnore()
         {
             METHOD_CANNOT_BE_FOLDED_DEBUG;
         }
@@ -479,7 +481,7 @@ extern "C"
     // Exception Handling ABI Level II: C++ ABI
     //
 
-    void *__cxa_begin_catch(void *exceptionObject);
+    void *__cxa_begin_catch(void *exceptionObject) throw();
     void __cxa_end_catch();
 
 #if defined(__cplusplus)
@@ -720,8 +722,7 @@ typedef GUID CLSID;
 #define REFCLSID const CLSID *
 #endif
 
-#define DECLSPEC_UUID(x) __declspec(uuid(x))
-#define MIDL_INTERFACE(x)   struct DECLSPEC_UUID(x) __declspec(novtable)
+#define MIDL_INTERFACE(x)   struct DECLSPEC_NOVTABLE
 
 #define EXTERN_GUID(itf,l1,s1,s2,c1,c2,c3,c4,c5,c6,c7,c8)                      \
     EXTERN_C const IID DECLSPEC_SELECTANY itf =                                \

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -33,7 +33,7 @@ public:
   unsigned int StartMSILOffset;
   unsigned int EndMSILOffset;
   bool IsVisited;
-  ReaderStack *ReaderStack;
+  ReaderStack *TheReaderStack;
 };
 
 class IRNode : public llvm::Value {};

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -15,7 +15,9 @@ set(LLVM_LINK_COMPONENTS
   native
   )
 
-if ( WIN32 )
+set(MSILCJIT_LINK_LIBRARIES msilcReader)
+
+if (WIN32)
   set(CMAKE_CXX_FLAGS "-EHsc")
 
   # Create .def file containing a list of exports preceeded by
@@ -34,6 +36,10 @@ if ( WIN32 )
 
   set(SHARED_LIB_SOURCES ${SOURCES} ${MSILCJIT_EXPORTS_DEF})
 else()
+  if (UNIX)
+    set(MSILCJIT_LINK_LIBRARIES ${MSILCJIT_LINK_LIBRARIES} coreclr)
+  endif()
+
   set(SHARED_LIB_SOURCES ${SOURCES})
 endif()
 
@@ -56,5 +62,5 @@ add_dependencies(
 target_link_libraries(
   msilcjit
   ${cmake_2_8_12_PRIVATE}
-  msilcReader
+  ${MSILCJIT_LINK_LIBRARIES}
   )

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1784,11 +1784,11 @@ FlowGraphNode *fgEdgeListGetSource(FlowGraphEdgeList *FgEdge) {
 }
 
 void GenIR::fgNodeSetOperandStack(FlowGraphNode *Fg, ReaderStack *Stack) {
-  FlowGraphInfoMap[Fg].ReaderStack = Stack;
+  FlowGraphInfoMap[Fg].TheReaderStack = Stack;
 }
 
 ReaderStack *GenIR::fgNodeGetOperandStack(FlowGraphNode *Fg) {
-  return FlowGraphInfoMap[Fg].ReaderStack;
+  return FlowGraphInfoMap[Fg].TheReaderStack;
 }
 
 bool GenIR::fgNodeIsVisited(FlowGraphNode *Fg) {


### PR DESCRIPTION
- libcoreclr need to be passed to the linker when linking libmsilcjit
  in order to avoid undefined symbol errors
- Replace a number of MSVC-specific attributes with their GCC/Clang
  equivalents
- Clean up some type/variable naming conflicts
- Migrate MSILCJit to use unique_ptr to track module ownership.
