### PR TITLE
Fix sign extension for lengthening converts to integers

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3009,19 +3009,20 @@ IRNode *GenIR::conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1,
   Type *SourceTy = Arg1->getType();
   Type *TargetTy = getType(Info.CorType, NULL);
   const bool SourceIsSigned = !Info.SourceIsUnsigned;
+  const bool DestIsSigned = TargetTy->isIntegerTy() && isSigned(Info.CorType);
   Value *Conversion = nullptr;
 
   if (SourceTy == TargetTy) {
     Conversion = Arg1;
   } else if (SourceTy->isIntegerTy() && TargetTy->isIntegerTy()) {
-    Conversion = LLVMBuilder->CreateIntCast(Arg1, TargetTy, SourceIsSigned);
+    Conversion = LLVMBuilder->CreateIntCast(Arg1, TargetTy, DestIsSigned);
   } else if (SourceTy->isPointerTy() && TargetTy->isIntegerTy()) {
     Conversion = LLVMBuilder->CreatePtrToInt(Arg1, TargetTy);
   } else if (SourceTy->isIntegerTy() && TargetTy->isFloatingPointTy()) {
     Conversion = SourceIsSigned ? LLVMBuilder->CreateSIToFP(Arg1, TargetTy)
       : LLVMBuilder->CreateUIToFP(Arg1, TargetTy);
   } else if (SourceTy->isFloatingPointTy() && TargetTy->isIntegerTy()) {
-    Conversion = SourceIsSigned ? LLVMBuilder->CreateFPToSI(Arg1, TargetTy)
+    Conversion = DestIsSigned ? LLVMBuilder->CreateFPToSI(Arg1, TargetTy)
       : LLVMBuilder->CreateFPToUI(Arg1, TargetTy);
   } else if (SourceTy->isFloatingPointTy() && TargetTy->isFloatingPointTy()) {
     Conversion = LLVMBuilder->CreateFPCast(Arg1, TargetTy);


### PR DESCRIPTION
When converting to an integral type, sign extend based on the destination type supplied by the opcode. We were using the source type, but source type is only relevant when converting from an integer type to a floating point type.

This fixes the FPConvDbl2Lng and FPConvF2Lng test cases in the CoreCLR bring up tests. No diffs in the current MSILC test suite.
