### PR TITLE
Delete uncalled flow-graph-related methods.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -539,14 +539,10 @@ IRNode *fgNodeGetStartIRNode(FlowGraphNode *FgNode);
 // Get the first non-placekeeping node in block
 IRNode *fgNodeGetStartInsertIRNode(FlowGraphNode *FgNode);
 
-// Get the special block-end placekeeping node
-IRNode *fgNodeGetEndIRNode(FlowGraphNode *FgNode);
-
 // Get the last non-placekeeping node in block
 IRNode *fgNodeGetEndInsertIRNode(FlowGraphNode *FgNode);
 
 IRNode *fgNodeGetEndIRInsertionPoint(FlowGraphNode *FgNode);
-void fgNodeSetIBCNotReal(FlowGraphNode *Fg);
 
 GlobalVerifyData *fgNodeGetGlobalVerifyData(FlowGraphNode *Fg);
 void fgNodeSetGlobalVerifyData(FlowGraphNode *Fg, GlobalVerifyData *GvData);
@@ -558,9 +554,9 @@ FlowGraphEdgeList *fgEdgeListGetNextPredecessor(FlowGraphEdgeList *FgEdge);
 FlowGraphNode *fgEdgeListGetSource(FlowGraphEdgeList *FgEdge);
 FlowGraphNode *fgEdgeListGetSink(FlowGraphEdgeList *FgEdge);
 bool fgEdgeListIsNominal(FlowGraphEdgeList *FgEdge);
-bool fgEdgeListIsHandler(FlowGraphEdgeList *FgEdge);
-bool fgEdgeListIsFake(FlowGraphEdgeList *FgEdge);
+#ifdef CC_PEVERIFY
 void fgEdgeListMakeFake(FlowGraphEdgeList *FgEdge);
+#endif
 
 FlowGraphEdgeList *fgEdgeListGetNextSuccessorActual(FlowGraphEdgeList *FgEdge);
 FlowGraphEdgeList *
@@ -1812,7 +1808,6 @@ public:
   virtual void fgPostPhase(void) = 0;
   virtual FlowGraphNode *fgGetHeadBlock(void) = 0;
   virtual FlowGraphNode *fgGetTailBlock(void) = 0;
-  virtual uint32_t fgGetBlockCount(void) = 0;
   virtual FlowGraphNode *fgNodeGetIDom(FlowGraphNode *Fg) = 0;
 
   virtual IRNode *fgNodeFindStartLabel(FlowGraphNode *Block) = 0;
@@ -1827,7 +1822,6 @@ public:
   virtual void fgAddArc(IRNode *BranchNode, FlowGraphNode *Source,
                         FlowGraphNode *Sink) = 0;
   virtual bool fgBlockHasFallThrough(FlowGraphNode *Block) = 0;
-  virtual bool fgBlockIsRegionEnd(FlowGraphNode *Block) = 0;
   virtual void fgDeleteBlock(FlowGraphNode *Block) = 0;
   virtual void fgDeleteEdge(FlowGraphEdgeList *Arc) = 0;
   virtual void fgDeleteNodesFromBlock(FlowGraphNode *Block) = 0;
@@ -1862,7 +1856,6 @@ public:
 
   virtual IRNode *fgMakeSwitch(IRNode *DefaultLabel, IRNode *Node) = 0;
   virtual IRNode *fgMakeThrow(IRNode *Node) = 0;
-  virtual IRNode *fgMakeRethrow(IRNode *Node) = 0;
   virtual IRNode *fgAddCaseToCaseList(IRNode *SwitchNode, IRNode *LabelNode,
                                       uint32_t Element) = 0;
   virtual void insertEHAnnotationNode(IRNode *InsertionPointNode,
@@ -1882,9 +1875,6 @@ public:
                       mdToken ConstraintToken, uint32_t ILOffset, IRNode *Block,
                       bool CanInline, bool IsTailCall, bool IsUnmarkedTailCall,
                       bool IsReadOnly) = 0;
-
-  // Hook to permit client to record when calls feed branches
-  virtual void fgCmp(ReaderBaseNS::OPCODE) = 0;
 
   // Replace all uses of oldNode in the IR with newNode and delete oldNode.
   virtual void replaceFlowGraphNodeUses(FlowGraphNode *OldNode,

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -489,7 +489,6 @@ public:
   void fgPostPhase(void) override;
   FlowGraphNode *fgGetHeadBlock(void) override;
   FlowGraphNode *fgGetTailBlock(void) override;
-  unsigned fgGetBlockCount(void) override;
   FlowGraphNode *fgNodeGetIDom(FlowGraphNode *Fg) override;
 
   IRNode *fgNodeFindStartLabel(FlowGraphNode *Block) override;
@@ -512,9 +511,6 @@ public:
   };
   bool fgBlockHasFallThrough(FlowGraphNode *Block) override;
 
-  bool fgBlockIsRegionEnd(FlowGraphNode *Block) override {
-    throw NotYetImplementedException("fgBlockIsRegionEnd");
-  };
   void fgDeleteBlock(FlowGraphNode *Block) override;
   void fgDeleteEdge(FlowGraphEdgeList *Arc) override {
     throw NotYetImplementedException("fgDeleteEdge");
@@ -564,9 +560,6 @@ public:
     throw NotYetImplementedException("fgMakeSwitch");
   };
   IRNode *fgMakeThrow(IRNode *Insert) override;
-  IRNode *fgMakeRethrow(IRNode *Insert) override {
-    throw NotYetImplementedException("fgMakeRethrow");
-  };
   IRNode *fgAddCaseToCaseList(IRNode *SwitchNode, IRNode *LabelNode,
                               unsigned Element) override {
     throw NotYetImplementedException("fgAddCaseToCaseList");
@@ -600,11 +593,6 @@ public:
               mdToken ConstraintToken, unsigned MsilOffset, IRNode *Block,
               bool CanInline, bool IsTailCall, bool IsUnmarkedTailCall,
               bool IsReadOnly) override;
-
-  // Hook to permit client to record when calls feed branches
-  void fgCmp(ReaderBaseNS::OPCODE) override {
-    throw NotYetImplementedException("fgCmp");
-  };
 
   // Replace all uses of oldNode in the IR with newNode and delete oldNode.
   void replaceFlowGraphNodeUses(FlowGraphNode *OldNode,

--- a/lib/Reader/GenIRStubs.cpp
+++ b/lib/Reader/GenIRStubs.cpp
@@ -25,16 +25,7 @@ IRNode *fgNodeGetStartInsertIRNode(FlowGraphNode *FgNode) {
   return fgNodeGetStartIRNode(FgNode);
 }
 
-// Get the special block-end placekeeping node
-IRNode *fgNodeGetEndIRNode(FlowGraphNode *FgNode) {
-  throw NotYetImplementedException("fFgNodeGetEndIRNode");
-}
-
 IRNode *fgNodeGetEndIRInsertionPoint(FlowGraphNode *FgNode) { return NULL; }
-
-void fgNodeSetIBCNotReal(FlowGraphNode *Fg) {
-  throw NotYetImplementedException("fgNodeSetIBCNotReal");
-}
 
 GlobalVerifyData *fgNodeGetGlobalVerifyData(FlowGraphNode *Fg) {
   throw NotYetImplementedException("fgNodeGetGlobalVerifyData");
@@ -48,17 +39,11 @@ uint32_t fgNodeGetBlockNum(FlowGraphNode *Fg) {
   throw NotYetImplementedException("fgNodeGetBlockNum");
 }
 
-bool fgEdgeListIsHandler(FlowGraphEdgeList *FgEdge) {
-  throw NotYetImplementedException("fgEdgeListIsHandler");
-}
-
-bool fgEdgeListIsFake(FlowGraphEdgeList *FgEdge) {
-  throw NotYetImplementedException("fgEdgeListIsFake");
-}
-
+#ifdef CC_PEVERIFY
 void fgEdgeListMakeFake(FlowGraphEdgeList *FgEdge) {
   throw NotYetImplementedException("fgEdgeListMakeFake");
 }
+#endif
 
 IRNode *irNodeGetNext(IRNode *Node) {
   throw NotYetImplementedException("irNodeGetNext");

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -3342,7 +3342,8 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
 
       // Make/insert end finally
       BlockNode = fgNodeGetStartIRNode(Block);
-      BranchNode = fgMakeEndFinally(BlockNode, CurrentOffset, IsLexicalEnd);
+      BranchNode = fgMakeEndFinallyHelper(BlockNode, CurrentOffset,
+                                                     IsLexicalEnd);
 
       // And split the block
       fgNodeSetEndMSILOffset(Block, NextOffset);

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1848,9 +1848,6 @@ IRNode *GenIR::fgNodeFindStartLabel(FlowGraphNode *Block) { return NULL; }
 
 bool GenIR::fgBlockHasFallThrough(FlowGraphNode *Block) { return false; }
 
-unsigned GenIR::fgGetBlockCount() {
-  return Function->getBasicBlockList().size();
-}
 #pragma endregion
 
 #pragma region MSIL OPCODES


### PR DESCRIPTION
- Deleted 8 uncalled fg\* methods.
- fgEdgeListMakeFake is only called under CC_PEVERIFY so I made the declaration and definition also conditional.
- I noticed that in one place fgMakeEndFinally is called instead of fgMakeEndFinallyHelper. That was changed during renaming rounds. Fixed that.
- Closes #5.
