### PR TITLE
Fix the Win32 Debug build.

### DIFF
--- a/include/Pal/MSILCPal.h
+++ b/include/Pal/MSILCPal.h
@@ -18,6 +18,9 @@
 // We still need the PAL EH macros on Windows, so define them here.
 #if defined(_MSC_VER)
 
+#if defined(_DEBUG)
+#include <windows.h> // For UINT
+#endif
 #include "staticcontract.h"
 
 // Note: PAL_SEH_RESTORE_GUARD_PAGE is only ever defined in clrex.h, so we only


### PR DESCRIPTION
staticcontract.h needs a definition for UINT in Win32 debug builds that
was not present after the PAL was refactored. This change conditionally
includes Windows.h before staticcontract.h in debug builds.

Fixes #39.
