### PR TITLE
Fix __stdcall compatibality issue

### DIFF
--- a/include/Jit/MSILCJit.h
+++ b/include/Jit/MSILCJit.h
@@ -16,6 +16,7 @@
 #ifndef MSILC_JIT_H
 #define MSILC_JIT_H
 
+#include "Pal/MSILCPal.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/ManagedStatic.h"

--- a/include/Pal/MSILCPal.h
+++ b/include/Pal/MSILCPal.h
@@ -23,6 +23,14 @@
 #endif
 #include "staticcontract.h"
 
+// Compatibility definitions for Architecture-specific attributes.
+//
+// __stdcall is X86 specific. MSVC ignores the attribute on other architectures,
+// whereas other compilers complain about the ignored attribute.
+#if !defined(_MSC_VER) && !defined(_HOST_X86_)
+#define __stdcall
+#endif // MSC_VER && _HOST_X86
+
 // Note: PAL_SEH_RESTORE_GUARD_PAGE is only ever defined in clrex.h, so we only
 // restore guard pages automatically when these macros are used from within the
 // VM.
@@ -167,10 +175,6 @@ extern "C" {
 #define __assume(x) (void)0
 
 #define UNALIGNED
-
-#if !defined(_HOST_X86_)
-#define __stdcall
-#endif
 
 #if defined(__GNUC__)
 #define __cdecl __attribute__((cdecl))


### PR DESCRIPTION
This change disables use of __stdcall attributes when building with non-VC++ compilers.
This avoids warnings when compiling using other compilers like Clang on Windows.

This change fixes [clang-diagnostic-ignored-attributes] generated by clang-tidy.
