### PR TITLE
Implement simple part of keep context alive and related methods

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -170,18 +170,14 @@ public:
     throw NotYetImplementedException("abs");
   };
 
-  IRNode *argList(IRNode **NewIR) override {
-    throw NotYetImplementedException("argList");
-  };
-  IRNode *instParam(IRNode **NewIR) override {
-    throw NotYetImplementedException("instParam");
-  };
+  IRNode *argList(IRNode **NewIR) override;
+  IRNode *instParam(IRNode **NewIR) override;
+  
   IRNode *secretParam(IRNode **NewIR) override {
     throw NotYetImplementedException("secretParam");
   };
-  IRNode *thisObj(IRNode **NewIR) override {
-    throw NotYetImplementedException("thisObj");
-  };
+  IRNode *thisObj(IRNode **NewIR) override;
+
   void boolBranch(ReaderBaseNS::BoolBranchOpcode Opcode, IRNode *Arg1,
                   IRNode **NewIR) override;
 
@@ -684,9 +680,7 @@ public:
             ReaderSpecialSymbolType SymType = Reader_NotSpecialSymbol) override;
 
   IRNode *derefAddress(IRNode *Address, bool DstIsGCPtr, bool IsConst,
-                       IRNode **NewIR) override {
-    throw NotYetImplementedException("derefAddress");
-  };
+                       IRNode **NewIR) override;
 
   IRNode *conditionalDerefAddress(IRNode *Address, IRNode **NewIR) override {
     throw NotYetImplementedException("conditionalDerefAddress");
@@ -776,6 +770,8 @@ private:
   llvm::Function *getFunction(CORINFO_METHOD_HANDLE Method);
 
   llvm::FunctionType *getFunctionType(CORINFO_METHOD_HANDLE Method);
+  llvm::FunctionType *getFunctionType(CORINFO_SIG_INFO &Sig,
+                                      CORINFO_CLASS_HANDLE ThisClass);
 
   llvm::Type *getClassType(CORINFO_CLASS_HANDLE ClassHandle,
                            bool IsRefClass, bool GetRefClassFields);
@@ -867,6 +863,7 @@ private:
   bool HasThis;
   bool HasTypeParameter;
   bool HasVarargsToken;
+  bool KeepGenericContextAlive;
   llvm::BasicBlock *EntryBlock;
   llvm::Instruction *TempInsertionPoint;
   uint32_t TargetPointerSizeInBits;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -5682,8 +5682,7 @@ ReaderBase::rdrGetVirtualStubCallTarget(ReaderCallTargetData *CallTargetData,
 }
 
 // Generate the target for a virtual call that will use the virtual
-// call table. This code path is deprecated and the runtime no longer
-// will ask the JIT to do this.
+// call table.
 IRNode *
 ReaderBase::rdrGetVirtualTableCallTarget(ReaderCallTargetData *CallTargetData,
                                          IRNode **ThisPtr, IRNode **NewIR) {
@@ -5694,7 +5693,7 @@ ReaderBase::rdrGetVirtualTableCallTarget(ReaderCallTargetData *CallTargetData,
   // VTable call uses method desc
   CallTargetData->UsesMethodDesc = true;
 
-  IRNode *VTableAddress = derefAddress(ThisPtrCopy, false, true, NewIR);
+  IRNode *VTableAddress = derefAddress(ThisPtrCopy, true, true, NewIR);
 
   // Get the VTable offset of the method.
   uint32_t OffsetOfIndirection;

--- a/test/add_i.base
+++ b/test/add_i.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/arrayalloc.base
+++ b/test/arrayalloc.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/beq.base
+++ b/test/beq.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/beq_i.base
+++ b/test/beq_i.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/clt_u4.base
+++ b/test/clt_u4.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/cyclic-type-graph.base
+++ b/test/cyclic-type-graph.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/field_tests.base
+++ b/test/field_tests.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/isinst.base
+++ b/test/isinst.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/ldarga_i.base
+++ b/test/ldarga_i.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/ldarga_i4.base
+++ b/test/ldarga_i4.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/ldc.base
+++ b/test/ldc.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/ldlen.base
+++ b/test/ldlen.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/ldloca.base
+++ b/test/ldloca.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/neg.base
+++ b/test/neg.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/newobj.base
+++ b/test/newobj.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/not.base
+++ b/test/not.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/null_eh.base
+++ b/test/null_eh.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/objalloc.base
+++ b/test/objalloc.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/shl.base
+++ b/test/shl.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/shr.base
+++ b/test/shr.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/simplearrayalloc.base
+++ b/test/simplearrayalloc.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/sizeof.base
+++ b/test/sizeof.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/stringalloc.base
+++ b/test/stringalloc.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/structalloc.base
+++ b/test/structalloc.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 

--- a/test/tailcall.base
+++ b/test/tailcall.base
@@ -148,7 +148,7 @@ Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
 INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
 Failed to read System.AppDomainSetup..ctor[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
 INFO:  jitting method System.String::Compare using LLILCJit
 Failed to read System.String.Compare[fgMakeSwitch]
 INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
@@ -388,7 +388,7 @@ Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
 INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
-Failed to read System.IO.PathHelper.ToString[derefAddress]
+Failed to read System.IO.PathHelper.ToString[Tail call]
 INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
 Successfully read System.String.CtorCharPtrStartLength
 
@@ -871,7 +871,7 @@ Failed to read System.Text.StringBuilder.ToString[loadElemA]
 INFO:  jitting method System.Buffer::_Memmove using LLILCJit
 Failed to read System.Buffer._Memmove[Tail call]
 INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
-Failed to read System.AppDomain.SetDataHelper[derefAddress]
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
 INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
 Successfully read System.AppDomain.get_LocalStore
 
@@ -909,11 +909,11 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
-Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Keep generic context alive]
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
 INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
 Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
 INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
-Failed to read System.RuntimeType.IsAssignableFrom[derefAddress]
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
 INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
 Successfully read System.RuntimeType.get_UnderlyingSystemType
 
@@ -949,15 +949,15 @@ Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System._
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
 Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
 INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[derefAddress]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
 INFO:  jitting method System.String::GetHashCode using LLILCJit
 Failed to read System.String.GetHashCode[Tail call]
 INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
@@ -969,7 +969,7 @@ Failed to read System.Text.StringBuilder..ctor[Tail call]
 INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
 Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
-Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[Keep generic context alive]
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
 INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method System.AppDomain::GetData using LLILCJit
@@ -1036,7 +1036,7 @@ Failed to read System.String.Equals[Tail call]
 INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
 Failed to read System.Threading.Monitor.Enter[Tail call]
 INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
-Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[Keep generic context alive]
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
 INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
 Failed to read System.AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
@@ -1117,7 +1117,66 @@ Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
 INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
 INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement..ctor[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
 INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
 Successfully read System.Security.PermissionSet.Copy
 
@@ -1160,13 +1219,64 @@ entry:
 INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
 Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
 INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
-Failed to read System.Security.Policy.PolicyStatement.get_PermissionSet[derefAddress]
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
 INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
 INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
-Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[Keep generic context alive]
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
 INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
 Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
 


### PR DESCRIPTION
Implement the simple part of `methodNeedsToKeepAliveGenericsContext`, where we don't actually need to keep anything alive.

Implement `thisObj` and related parameter fetchers.

Implement `derefAddress`, which is used to tunnel into opaque EE data. Lots of casting required here. 

Update the vtable type we use for objects to indicate it points at an array of pointer-sized things, and fix a couple of other char *'s to be intptr_t *'s for similar reasons.

Factor `getFunctionType` so we can call it on a signature, use this to cast vtable fetches to the right types.

We now handle a few more methods in the initial test suite, and have updated fail reasons on a bunch more.
