### PR TITLE
Update path to PassManager to fix build break

### DIFF
--- a/lib/Jit/EEMemoryManager.cpp
+++ b/lib/Jit/EEMemoryManager.cpp
@@ -25,7 +25,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/IRReader/IRReader.h"
-#include "llvm/PassManager.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"

--- a/lib/Jit/MSILCJit.cpp
+++ b/lib/Jit/MSILCJit.cpp
@@ -27,7 +27,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
-#include "llvm/PassManager.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"

--- a/test/MSILCEnv.ps1
+++ b/test/MSILCEnv.ps1
@@ -17,7 +17,7 @@
 
     2. LLVM and MSILC source are downloaded and an LLVM build directory
     are specified. Note that MSILC source should be located at the
-    correct place under LLVM: tools\llvm-msilc .
+    correct place under LLVM: tools\llilc .
     
     3. A separate MSILC work directory is specified, where CLR, MSILC
     JIT, and test cases from CLR drop will be copied into so that you can
@@ -253,12 +253,12 @@ function ValidatePreConditions
   # Validate MSILC
 
   if ($LLVMSourceExists) {
-    $MSILCSourceExists = Test-Path "$Env:LLVMSOURCE\tools\llvm-msilc"
+    $MSILCSourceExists = Test-Path "$Env:LLVMSOURCE\tools\llilc"
     if (!$MSILCSourceExists) {
       throw "!!! MSILC Source not available."
     }
     else {
-      $Env:MSILCSOURCE = "$Env:LLVMSOURCE\tools\llvm-msilc"
+      $Env:MSILCSOURCE = "$Env:LLVMSOURCE\tools\llilc"
     }
   }
 


### PR DESCRIPTION
Recent LLVM update moved a header. Fix the path we use to point to the new location.
