### PR TITLE
Dox2

### DIFF
--- a/include/Jit/EEMemoryManager.h
+++ b/include/Jit/EEMemoryManager.h
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Declaration of the memory manager interface to the EE.
-//
+///
+/// \file
+/// \brief Declaration of the memory manager interface to the EE.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef EE_MEMORYMANAGER_H

--- a/include/Jit/global.h
+++ b/include/Jit/global.h
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Host and target defines.
-//
+///
+/// \file
+/// \brief Host and target defines.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef JIT_GLOBAL_H

--- a/include/Jit/jitpch.h
+++ b/include/Jit/jitpch.h
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Jit precompiled header
-//
+///
+/// \file
+/// \brief Jit precompiled header
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef JIT_PCH_H

--- a/include/Pal/Rt/ole2.h
+++ b/include/Pal/Rt/ole2.h
@@ -7,7 +7,8 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Dummy ole2.h for non-Windows platforms.
-//
+///
+/// \file
+/// \brief Dummy ole2.h for non-Windows platforms.
+///
 //===----------------------------------------------------------------------===//

--- a/include/Pal/Rt/specstrings.h
+++ b/include/Pal/Rt/specstrings.h
@@ -7,7 +7,8 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Dummy specstrings.h for non-Windows platforms.
-//
+///
+/// \file
+/// \brief Dummy specstrings.h for non-Windows platforms.
+///
 //===----------------------------------------------------------------------===//

--- a/include/Pal/Rt/windef.h
+++ b/include/Pal/Rt/windef.h
@@ -7,7 +7,8 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Dummy windef.h for non-Windows platforms.
-//
+///
+/// \file
+/// \brief Dummy windef.h for non-Windows platforms.
+///
 //===----------------------------------------------------------------------===//

--- a/include/Pal/Rt/winerror.h
+++ b/include/Pal/Rt/winerror.h
@@ -7,7 +7,8 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Dummy winerror.h for non-Windows platforms.
-//
+///
+/// \file
+/// \brief Dummy winerror.h for non-Windows platforms.
+///
 //===----------------------------------------------------------------------===//

--- a/include/Reader/gverify.h
+++ b/include/Reader/gverify.h
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Declares data structures useful for MSIL bytecode verification.
-//
+///
+/// \file
+/// \brief Declares data structures useful for MSIL bytecode verification.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef MSIL_READER_GVERIFY_H

--- a/include/Reader/newvstate.h
+++ b/include/Reader/newvstate.h
@@ -10,7 +10,7 @@
 ///
 /// \file
 /// \brief Data structures for holding verification state.
-//
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef MSIL_READER_NEW_VSTATE_H

--- a/include/Reader/ophelper.def
+++ b/include/Reader/ophelper.def
@@ -7,13 +7,27 @@
 // See LICENSE file in the project root for full license information. 
 //
 //===----------------------------------------------------------------------===//
-//
-// Include file to make cleaner use of the opcode.def file to create mappings
-// for info on MSIL ops.
-//
-// To use this header:
-// #define OPDEF_HELPER
-//
+///
+/// \file
+/// \brief Include file to make cleaner use of the opcode.def file to create mappings
+/// for info on MSIL ops.
+///
+/// To use this header you must use
+///
+/// ~~~
+/// #define OPDEF_HELPER <desired-result>
+/// #include ophelper.def
+/// ~~~
+///
+/// This has the effect of extracting information from the opcode.def file. In particular
+/// a list of values is produced suitable for initializing a table.
+/// 
+/// <desired-result> is one of these:
+/// - OPDEF_OPCODENAME: to get the opcode name
+/// - OPDEF_OPERANDSIZE: to get the operand size
+/// - OPDEF_PUSHCOUNT: to get the number of operands pushed
+/// - OPDEF_POPCOUNT: to get the number of operands popped
+/// - OPDEF_ISBRANCH: to tell if opcode is for a conditional branch.
 //===----------------------------------------------------------------------===//
 
 #ifndef OPDEF_HELPER
@@ -24,7 +38,7 @@
 #define OPDEF_OPERANDSIZE   123002
 #define OPDEF_PUSHCOUNT     123003
 #define OPDEF_POPCOUNT      123004
-#define OPDEF_ISBRACH       123005
+#define OPDEF_ISBRANCH      123005
 
 
 #if OPDEF_HELPER == OPDEF_OPCODENAME

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -7,10 +7,11 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Declares the ReaderBase class, which provides a generic framework for
-// translating MSIL bytecode into some other representation.
-//
+///
+/// \file
+/// \brief Declares the ReaderBase class, which provides a generic framework for
+/// translating MSIL bytecode into some other representation.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef MSIL_READER_H

--- a/include/Reader/readerenum.h
+++ b/include/Reader/readerenum.h
@@ -7,10 +7,11 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Enumerations that are useful in translating from MSIL bytecode to some
-// other representation.
-//
+///
+/// \file
+/// \brief Enumerations that are useful in translating from MSIL bytecode to some
+/// other representation.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef MSIL_READER_ENUM_H

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -7,10 +7,11 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Declares the GenIR class, which overrides ReaderBase to generate LLVM IR
-// from MSIL bytecode.
-//
+///
+/// \file
+/// \brief Declares the GenIR class, which overrides ReaderBase to generate LLVM IR
+/// from MSIL bytecode.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef MSIL_READER_IR_H

--- a/include/Reader/vtypeinfo.h
+++ b/include/Reader/vtypeinfo.h
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Type information for an MSIL verifier.
-//
+///
+/// \file
+/// \brief Type information for an MSIL verifier.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef MSIL_READER_TYPEINFO_H

--- a/include/Reader/vtypeinfodbg.def
+++ b/include/Reader/vtypeinfodbg.def
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Result code literals for Verifier Type Interface
-//
+///
+/// \file
+/// \brief Result code literals for Verifier Type Interface
+///
 //===----------------------------------------------------------------------===//
 
 #define MVER_E_HRESULT           "[HRESULT 0x%08X]"

--- a/include/Reader/vtypeinfores.def
+++ b/include/Reader/vtypeinfores.def
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Debugging String literal definitions for Verifier Type Interface
-//
+///
+/// \file
+/// \brief Debugging String literal definitions for Verifier Type Interface
+///
 //===----------------------------------------------------------------------===//
 
 #define MVER_E_HRESULT                        VER_E_HRESULT

--- a/lib/Reader/GenIRStubs.cpp
+++ b/lib/Reader/GenIRStubs.cpp
@@ -7,10 +7,11 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Common reader functionality that is either not yet implemented
-// or stubbed out.
-//
+///
+/// \file
+/// \brief Common reader functionality that is either not yet implemented
+/// or stubbed out.
+///
 //===----------------------------------------------------------------------===//
 
 #include "reader.h"

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -7,19 +7,20 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Common code for converting MSIL bytecode into some other representation.
-//
-// The common reader's operation revolves around two central classes.
-// ReaderBase:: the common reader class
-// GenIR::      an opaque vessel for holding the client's state
-//
-// The GenIR class is opaque to the common reader class, all manipulations of
-// GenIR are performed by client implemented code.
-//
-// The common reader generates code through the methods that are implemented in
-// this file, and static member functions that are implemented by the client.
-//
+///
+/// \file
+/// \brief Common code for converting MSIL bytecode into some other representation.
+///
+/// The common reader's operation revolves around two central classes.
+/// ReaderBase:: the common reader class
+/// GenIR::      an opaque vessel for holding the client's state
+///
+/// The GenIR class is opaque to the common reader class, all manipulations of
+/// GenIR are performed by client implemented code.
+///
+/// The common reader generates code through the methods that are implemented in
+/// this file, and static member functions that are implemented by the client.
+///
 //===----------------------------------------------------------------------===//
 
 #include "reader.h"

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -7,9 +7,10 @@
 // See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
-//
-// Convert from MSIL bytecode to LLVM IR.
-//
+///
+/// \file
+/// \brief Convert from MSIL bytecode to LLVM IR.
+///
 //===----------------------------------------------------------------------===//
 
 #include "readerir.h"


### PR DESCRIPTION
In preparation for adding more detailed documentation comments that can be extracted by Doxygen,
add "\file" and "\brief" markup on all LLILC C++ files that lack such markup, except for
header files imported from the CLR (which LLILC does not own).
