### PR TITLE
Add Lab Job Badges to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Welcome to LLILC
 
+## Build Status
 |   |Windows|Linux|
 |:-:|:-:|:-:|
 |**Debug**|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_windows_debug_win64/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_windows_debug_win64/)|[![Build Status](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_linux_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_linux_debug/)|
 |**Release**|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_windows_release_win64/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_windows_release_win64/)|[![Build Status](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_linux_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_llilc_linux_release/)|
 
 ## Introduction
-LLILC is an **LL**VM based MS**IL** **C**ompiler - we pronounce it 'lilac' - with a goal of producing a set of cross-platform .NET code generation tools. Today LLILC is being developed against the [dotnet/CoreCLR](https://github.com/dotnet/coreclr) for use as a JIT, but an ahead of time (AOT) compiler planned for the future.  
+LLILC is an **LL**VM based MS**IL** **C**ompiler - we pronounce it 'lilac' - with a goal of producing a set of cross-platform .NET code generation tools. Today LLILC is being developed against [dotnet/CoreCLR](https://github.com/dotnet/coreclr) for use as a JIT, but an ahead of time (AOT) compiler is planned for the future.  
 
 See the [wiki](https://github.com/dotnet/llilc/wiki) for more information.  It has a more complete discussion of our background and goals as well as "getting started" details and developer information.
 


### PR DESCRIPTION
Currently, the lab badges look like broken links. When our jobs are public (ie, when we go public), they will be little badges that say "build running" or "build passing" or "build failing" similar to the badges in the coreclr readme.
