### PR TITLE
Reword Contributing section to avoid a grammar problem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Our initial supported platform is Windows, but Linux and Mac OSX support is unde
 
 
 ## Contributions
-LLILC is just starting up.  Only a few tests are working and there are lots of future work to do.  Please see our [issues](https://github.com/dotnet/llilc/issues) or the [contributing page](https://github.com/dotnet/llilc/wiki/Contributing) for how to pitch in.
+LLILC is just starting up.  Only a few tests are working and there are lots of places where we need help.  Please see our [issues](https://github.com/dotnet/llilc/issues) or the [contributing page](https://github.com/dotnet/llilc/wiki/Contributing) for how to pitch in.
 
 


### PR DESCRIPTION
Simple fix to avoid the 'are lots of future work' grammar problem.
