### PR TITLE
Fix for bug #93.

### DIFF
--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -2486,6 +2486,8 @@ ReaderBase::fgReplaceBranchTarget(uint32_t Offset,
     StartBlock = fgGetHeadBlock();
   }
 
+  bool FoundTargetBlock = false;
+
   // Iterate over all blocks until block that contains the offset is found.
   for (Block = StartBlock; Block != NULL; Block = NextBlock) {
 
@@ -2519,9 +2521,13 @@ ReaderBase::fgReplaceBranchTarget(uint32_t Offset,
       // the branch instructions.
       replaceFlowGraphNodeUses(TempBranchTarget, Block);
 
+      FoundTargetBlock = true;
+
       break;
     }
   }
+
+  ASSERTNR(FoundTargetBlock);
 
   return Block;
 }
@@ -3381,7 +3387,7 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
       verifyReturnFlow(CurrentOffset);
       fgNodeSetEndMSILOffset(Block, NextOffset);
       if (NextOffset < ILInputSize) {
-        Block = makeFlowGraphNode(TargetOffset, NULL);
+        Block = makeFlowGraphNode(NextOffset, NULL);
       }
       break;
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1710,7 +1710,8 @@ FlowGraphNode *GenIR::fgSplitBlock(FlowGraphNode *Block, IRNode *Node) {
   BasicBlock *TheBasicBlock = (BasicBlock *)Block;
   BasicBlock *NewBlock;
   if (Inst == NULL) {
-    NewBlock = BasicBlock::Create(*JitContext->LLVMContext, "", Function);
+    NewBlock = BasicBlock::Create(*JitContext->LLVMContext, "", Function,
+      TheBasicBlock->getNextNode());
     TerminatorInst *TermInst = TheBasicBlock->getTerminator();
     if (TermInst != NULL) {
       if (isa<UnreachableInst>(TermInst)) {

--- a/test/MSILCRegr.lst
+++ b/test/MSILCRegr.lst
@@ -23,3 +23,4 @@ ldlen
 field_tests
 newobj
 isinst
+bug93

--- a/test/bug93.base
+++ b/test/bug93.base
@@ -1,0 +1,1360 @@
+INFO:  jitting method System.AppDomain::SetupDomain using LLILCJit
+Failed to read System.AppDomain.SetupDomain[Call needs null check]
+INFO:  jitting method System.AppDomain::SetupFusionStore using LLILCJit
+Failed to read System.AppDomain.SetupFusionStore[Call needs null check]
+INFO:  jitting method System.AppDomainSetup::VerifyDir using LLILCJit
+Successfully read System.AppDomainSetup.VerifyDir
+
+define %System.String addrspace(1)* @System.AppDomainSetup.VerifyDir(%System.AppDomainSetup addrspace(1)* %param0, %System.String addrspace(1)* %param1, i8 %param2) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i8
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i8 %param2, i8* %arg2
+  %0 = load %System.String addrspace(1)** %arg1
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %16, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** %arg1
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %8, label %7
+
+; <label>:7                                       ; preds = %2
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %arg1
+  br label %16
+
+; <label>:8                                       ; preds = %2
+  %9 = load i8* %arg2
+  %10 = zext i8 %9 to i32
+  %11 = icmp eq i32 %10, 0
+  br i1 %11, label %16, label %12
+
+; <label>:12                                      ; preds = %8
+  %13 = load %System.AppDomainSetup addrspace(1)** %this
+  %14 = load %System.String addrspace(1)** %arg1
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.AppDomainSetup addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.AppDomainSetup addrspace(1)* %13, %System.String addrspace(1)* %14, i8 1)
+  store %System.String addrspace(1)* %15, %System.String addrspace(1)** %arg1
+  br label %16
+
+; <label>:16                                      ; preds = %entry, %7, %8, %12
+  %17 = load %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %17
+}
+
+INFO:  jitting method System.AppDomainSetup::SetupDefaults using LLILCJit
+Failed to read System.AppDomainSetup.SetupDefaults[storeElem]
+INFO:  jitting method System.String::LastIndexOfAny using LLILCJit
+Failed to read System.String.LastIndexOfAny[Tail call]
+INFO:  jitting method System.String::Substring using LLILCJit
+Failed to read System.String.Substring[Tail call]
+INFO:  jitting method System.String::InternalSubString using LLILCJit
+Failed to read System.String.InternalSubString[genNullCheck]
+INFO:  jitting method System.Buffer::Memmove using LLILCJit
+Failed to read System.Buffer.Memmove[fgMakeSwitch]
+INFO:  jitting method System.String::Concat using LLILCJit
+Successfully read System.String.Concat
+
+define %System.String addrspace(1)* @System.String.Concat(%System.String addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i32
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %13, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** %arg1
+  %6 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %5)
+  %7 = zext i8 %6 to i32
+  %8 = icmp eq i32 %7, 0
+  br i1 %8, label %11, label %9
+
+; <label>:9                                       ; preds = %4
+  %10 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %10
+
+; <label>:11                                      ; preds = %4
+  %12 = load %System.String addrspace(1)** %arg1
+  ret %System.String addrspace(1)* %12
+
+; <label>:13                                      ; preds = %entry
+  %14 = load %System.String addrspace(1)** %arg1
+  %15 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = zext i8 %15 to i32
+  %17 = icmp eq i32 %16, 0
+  br i1 %17, label %20, label %18
+
+; <label>:18                                      ; preds = %13
+  %19 = load %System.String addrspace(1)** %arg0
+  ret %System.String addrspace(1)* %19
+
+; <label>:20                                      ; preds = %13
+  %21 = load %System.String addrspace(1)** %arg0
+  %22 = getelementptr inbounds %System.String addrspace(1)* %21, i32 0, i32 1
+  %23 = load i32 addrspace(1)* %22
+  store i32 %23, i32* %loc0
+  %24 = load i32* %loc0
+  %25 = load %System.String addrspace(1)** %arg1
+  %26 = getelementptr inbounds %System.String addrspace(1)* %25, i32 0, i32 1
+  %27 = load i32 addrspace(1)* %26
+  %28 = add i32 %24, %27
+  %29 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %28)
+  %30 = load %System.String addrspace(1)** %arg0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, i32 0, %System.String addrspace(1)* %30)
+  %31 = load i32* %loc0
+  %32 = load %System.String addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)*, i32, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, i32 %31, %System.String addrspace(1)* %32)
+  ret %System.String addrspace(1)* %29
+}
+
+INFO:  jitting method System.String::IsNullOrEmpty using LLILCJit
+Successfully read System.String.IsNullOrEmpty
+
+define i8 @System.String.IsNullOrEmpty(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = icmp eq %System.String addrspace(1)* %0, null
+  br i1 %1, label %9, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** %arg0
+  %4 = getelementptr inbounds %System.String addrspace(1)* %3, i32 0, i32 1
+  %5 = load i32 addrspace(1)* %4
+  %6 = icmp eq i32 %5, 0
+  %7 = sext i1 %6 to i32
+  %8 = trunc i32 %7 to i8
+  ret i8 %8
+
+; <label>:9                                       ; preds = %entry
+  ret i8 1
+}
+
+INFO:  jitting method System.String::FillStringChecked using LLILCJit
+Failed to read System.String.FillStringChecked[genNullCheck]
+INFO:  jitting method System.AppDomain::PrepareDataForSetup using LLILCJit
+Failed to read System.AppDomain.PrepareDataForSetup[Call needs null check]
+INFO:  jitting method System.AppDomainSetup::.ctor using LLILCJit
+Failed to read System.AppDomainSetup..ctor[Call needs null check]
+INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.cctor using LLILCJit
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..cctor[callRuntimeHandleHelper]
+INFO:  jitting method System.String::Compare using LLILCJit
+Failed to read System.String.Compare[fgMakeSwitch]
+INFO:  jitting method System.String::CompareOrdinalIgnoreCaseHelper using LLILCJit
+Failed to read System.String.CompareOrdinalIgnoreCaseHelper[genNullCheck]
+INFO:  jitting method System.AppDomain::Setup using LLILCJit
+Failed to read System.AppDomain.Setup[loadElem]
+INFO:  jitting method System.Threading.Thread::GetDomain using LLILCJit
+Successfully read System.Threading.Thread.GetDomain
+
+define %System.AppDomain addrspace(1)* @System.Threading.Thread.GetDomain() {
+entry:
+  %loc0 = alloca %System.AppDomain addrspace(1)*
+  %0 = call %System.AppDomain addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomain addrspace(1)* ()*)()
+  store %System.AppDomain addrspace(1)* %0, %System.AppDomain addrspace(1)** %loc0
+  %1 = load %System.AppDomain addrspace(1)** %loc0
+  %2 = icmp ne %System.AppDomain addrspace(1)* %1, null
+  br i1 %2, label %5, label %3
+
+; <label>:3                                       ; preds = %entry
+  %4 = call %System.AppDomain addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomain addrspace(1)* ()*)()
+  store %System.AppDomain addrspace(1)* %4, %System.AppDomain addrspace(1)** %loc0
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %3
+  %6 = load %System.AppDomain addrspace(1)** %loc0
+  ret %System.AppDomain addrspace(1)* %6
+}
+
+INFO:  jitting method System.AppDomainSetup::GetConfigurationBytes using LLILCJit
+Failed to read System.AppDomainSetup.GetConfigurationBytes[Call needs null check]
+INFO:  jitting method System.AppDomainSetup::get_TargetFrameworkName using LLILCJit
+Failed to read System.AppDomainSetup.get_TargetFrameworkName[Call needs null check]
+INFO:  jitting method System.AppDomain::get_FusionStore using LLILCJit
+Successfully read System.AppDomain.get_FusionStore
+
+define %System.AppDomainSetup addrspace(1)* @System.AppDomain.get_FusionStore(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 3
+  %2 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ugt %System.AppDomainSetup addrspace(1)* %2, null
+  %4 = sext i1 %3 to i32
+  %5 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = trunc i32 %4 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8, %System.String addrspace(1)*)*)(i8 %6, %System.String addrspace(1)* %5)
+  %7 = load %System.AppDomain addrspace(1)** %this
+  %8 = getelementptr inbounds %System.AppDomain addrspace(1)* %7, i32 0, i32 3
+  %9 = load %System.AppDomainSetup addrspace(1)* addrspace(1)* %8, align 8
+  ret %System.AppDomainSetup addrspace(1)* %9
+}
+
+INFO:  jitting method System.Diagnostics.Contracts.Contract::Assert using LLILCJit
+Failed to read System.Diagnostics.Contracts.Contract.Assert[Tail call]
+INFO:  jitting method System.String::Equals using LLILCJit
+Failed to read System.String.Equals[Tail call]
+INFO:  jitting method System.String::EqualsHelper using LLILCJit
+Failed to read System.String.EqualsHelper[genNullCheck]
+INFO:  jitting method System.Text.StringBuilder::.ctor using LLILCJit
+Failed to read System.Text.StringBuilder..ctor[storeElem]
+INFO:  jitting method System.Text.StringBuilder::ThreadSafeCopy using LLILCJit
+Failed to read System.Text.StringBuilder.ThreadSafeCopy[loadElemA]
+INFO:  jitting method System.IO.Path::.cctor using LLILCJit
+Failed to read System.IO.Path..cctor[storeStaticField]
+INFO:  jitting method System.String::SplitInternal using LLILCJit
+Failed to read System.String.SplitInternal[Tail call]
+INFO:  jitting method System.String::MakeSeparatorList using LLILCJit
+Failed to read System.String.MakeSeparatorList[genNullCheck]
+INFO:  jitting method System.String::InternalSplitKeepEmptyEntries using LLILCJit
+Failed to read System.String.InternalSplitKeepEmptyEntries[loadElem]
+INFO:  jitting method System.IO.Path::IsRelative using LLILCJit
+Successfully read System.IO.Path.IsRelative
+
+define i8 @System.IO.Path.IsRelative(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = icmp ugt %System.String addrspace(1)* %0, null
+  %2 = sext i1 %1 to i32
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = trunc i32 %2 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8, %System.String addrspace(1)*)*)(i8 %4, %System.String addrspace(1)* %3)
+  %5 = load %System.String addrspace(1)** %arg0
+  %6 = getelementptr inbounds %System.String addrspace(1)* %5, i32 0, i32 1
+  %7 = load i32 addrspace(1)* %6
+  %8 = icmp slt i32 %7, 3
+  br i1 %8, label %55, label %9
+
+; <label>:9                                       ; preds = %entry
+  %10 = load %System.String addrspace(1)** %arg0
+  %11 = getelementptr inbounds %System.String addrspace(1)* %10, i32 0, i32 2, i32 1
+  %12 = load i16 addrspace(1)* %11
+  %13 = zext i16 %12 to i32
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 328)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 2112
+  %16 = addrspacecast i8 addrspace(1)* %15 to i16*
+  %17 = load i16* %16
+  %18 = zext i16 %17 to i32
+  %19 = icmp ne i32 %13, %18
+  br i1 %19, label %55, label %20
+
+; <label>:20                                      ; preds = %9
+  %21 = load %System.String addrspace(1)** %arg0
+  %22 = getelementptr inbounds %System.String addrspace(1)* %21, i32 0, i32 2, i32 2
+  %23 = load i16 addrspace(1)* %22
+  %24 = zext i16 %23 to i32
+  %25 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 328)
+  %26 = getelementptr inbounds i8 addrspace(1)* %25, i64 2108
+  %27 = addrspacecast i8 addrspace(1)* %26 to i16*
+  %28 = load i16* %27
+  %29 = zext i16 %28 to i32
+  %30 = icmp ne i32 %24, %29
+  br i1 %30, label %55, label %31
+
+; <label>:31                                      ; preds = %20
+  %32 = load %System.String addrspace(1)** %arg0
+  %33 = getelementptr inbounds %System.String addrspace(1)* %32, i32 0, i32 2, i32 0
+  %34 = load i16 addrspace(1)* %33
+  %35 = zext i16 %34 to i32
+  %36 = icmp slt i32 %35, 97
+  br i1 %36, label %43, label %37
+
+; <label>:37                                      ; preds = %31
+  %38 = load %System.String addrspace(1)** %arg0
+  %39 = getelementptr inbounds %System.String addrspace(1)* %38, i32 0, i32 2, i32 0
+  %40 = load i16 addrspace(1)* %39
+  %41 = zext i16 %40 to i32
+  %42 = icmp sle i32 %41, 122
+  br i1 %42, label %72, label %43
+
+; <label>:43                                      ; preds = %31, %37
+  %44 = load %System.String addrspace(1)** %arg0
+  %45 = getelementptr inbounds %System.String addrspace(1)* %44, i32 0, i32 2, i32 0
+  %46 = load i16 addrspace(1)* %45
+  %47 = zext i16 %46 to i32
+  %48 = icmp slt i32 %47, 65
+  br i1 %48, label %55, label %49
+
+; <label>:49                                      ; preds = %43
+  %50 = load %System.String addrspace(1)** %arg0
+  %51 = getelementptr inbounds %System.String addrspace(1)* %50, i32 0, i32 2, i32 0
+  %52 = load i16 addrspace(1)* %51
+  %53 = zext i16 %52 to i32
+  %54 = icmp sle i32 %53, 90
+  br i1 %54, label %72, label %55
+
+; <label>:55                                      ; preds = %entry, %9, %20, %43, %49
+  %56 = load %System.String addrspace(1)** %arg0
+  %57 = getelementptr inbounds %System.String addrspace(1)* %56, i32 0, i32 1
+  %58 = load i32 addrspace(1)* %57
+  %59 = icmp slt i32 %58, 2
+  br i1 %59, label %73, label %60
+
+; <label>:60                                      ; preds = %55
+  %61 = load %System.String addrspace(1)** %arg0
+  %62 = getelementptr inbounds %System.String addrspace(1)* %61, i32 0, i32 2, i32 0
+  %63 = load i16 addrspace(1)* %62
+  %64 = zext i16 %63 to i32
+  %65 = icmp ne i32 %64, 92
+  br i1 %65, label %73, label %66
+
+; <label>:66                                      ; preds = %60
+  %67 = load %System.String addrspace(1)** %arg0
+  %68 = getelementptr inbounds %System.String addrspace(1)* %67, i32 0, i32 2, i32 1
+  %69 = load i16 addrspace(1)* %68
+  %70 = zext i16 %69 to i32
+  %71 = icmp ne i32 %70, 92
+  br i1 %71, label %73, label %72
+
+; <label>:72                                      ; preds = %37, %49, %66
+  ret i8 0
+
+; <label>:73                                      ; preds = %55, %60, %66
+  ret i8 1
+}
+
+INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
+Failed to read System.IO.Path.NormalizePath[entryLabel]
+INFO:  jitting method System.String::TrimHelper using LLILCJit
+Failed to read System.String.TrimHelper[loadElem]
+INFO:  jitting method System.String::CreateTrimmedString using LLILCJit
+Failed to read System.String.CreateTrimmedString[Tail call]
+INFO:  jitting method System.IO.Path::CheckInvalidPathChars using LLILCJit
+Successfully read System.IO.Path.CheckInvalidPathChars
+
+define void @System.IO.Path.CheckInvalidPathChars(%System.String addrspace(1)* %param0, i8 %param1) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  %arg1 = alloca i8
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  store i8 %param1, i8* %arg1
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = icmp ne %System.String addrspace(1)* %0, null
+  br i1 %1, label %5, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = call %System.ArgumentNullException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentNullException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4, %System.String addrspace(1)* %3)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentNullException addrspace(1)*)*)(%System.ArgumentNullException addrspace(1)* %4) #0
+  unreachable
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** %arg0
+  %7 = load i8* %arg1
+  %8 = zext i8 %7 to i32
+  %9 = trunc i32 %8 to i8
+  %10 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, i8)*)(%System.String addrspace(1)* %6, i8 %9)
+  %11 = zext i8 %10 to i32
+  %12 = icmp eq i32 %11, 0
+  br i1 %12, label %17, label %13
+
+; <label>:13                                      ; preds = %5
+  %14 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %14)
+  %16 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %16, %System.String addrspace(1)* %15)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %16) #0
+  unreachable
+
+; <label>:17                                      ; preds = %5
+  ret void
+}
+
+INFO:  jitting method System.IO.Path::HasIllegalCharacters using LLILCJit
+Failed to read System.IO.Path.HasIllegalCharacters[Call needs null check]
+INFO:  jitting method System.IO.PathHelper::Append using LLILCJit
+Failed to read System.IO.PathHelper.Append[storePrimitiveType]
+INFO:  jitting method System.IO.PathHelper::OrdinalStartsWith using LLILCJit
+Failed to read System.IO.PathHelper.OrdinalStartsWith[Tail call]
+INFO:  jitting method System.IO.PathHelper::NullTerminate using LLILCJit
+Failed to read System.IO.PathHelper.NullTerminate[storePrimitiveType]
+INFO:  jitting method System.IO.PathHelper::GetFullPathName using LLILCJit
+Failed to read System.IO.PathHelper.GetFullPathName[entryLabel]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+INFO:  jitting method System.IO.PathHelper::ToString using LLILCJit
+Failed to read System.IO.PathHelper.ToString[Tail call]
+INFO:  jitting method System.String::CtorCharPtrStartLength using LLILCJit
+Successfully read System.String.CtorCharPtrStartLength
+
+define %System.String addrspace(1)* @System.String.CtorCharPtrStartLength(%System.String addrspace(1)* %param0, i16* %param1, i32 %param2, i32 %param3) {
+entry:
+  %this = alloca %System.String addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %arg3 = alloca i32
+  %loc0 = alloca i16*
+  %loc1 = alloca %System.String addrspace(1)*
+  %loc2 = alloca i16*
+  %loc3 = alloca %System.String addrspace(1)*
+  %loc4 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  store i32 %param3, i32* %arg3
+  %0 = load i32* %arg3
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg2
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load %System.String addrspace(1)** %this
+  %17 = icmp eq %System.String addrspace(1)* %16, null
+  %18 = sext i1 %17 to i32
+  %19 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %20 = trunc i32 %18 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8, %System.String addrspace(1)*)*)(i8 %20, %System.String addrspace(1)* %19)
+  %21 = load i16** %arg1
+  %22 = load i32* %arg2
+  %23 = sext i32 %22 to i64
+  %24 = mul i64 %23, 2
+  %25 = bitcast i16* %21 to i8*
+  %26 = getelementptr inbounds i8* %25, i64 %24
+  %27 = bitcast i8* %26 to i16*
+  store i16* %27, i16** %loc0
+  %28 = load i16** %loc0
+  %29 = load i16** %arg1
+  %30 = icmp uge i16* %28, %29
+  br i1 %30, label %36, label %31
+
+; <label>:31                                      ; preds = %15
+  %32 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %33 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %34 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %33)
+  %35 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %35, %System.String addrspace(1)* %32, %System.String addrspace(1)* %34)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %35) #0
+  unreachable
+
+; <label>:36                                      ; preds = %15
+  %37 = load i32* %arg3
+  %38 = icmp ne i32 %37, 0
+  br i1 %38, label %41, label %39
+
+; <label>:39                                      ; preds = %36
+  %40 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %40
+
+; <label>:41                                      ; preds = %36
+  %42 = load i32* %arg3
+  %43 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (i32)*)(i32 %42)
+  store %System.String addrspace(1)* %43, %System.String addrspace(1)** %loc1
+  %44 = load %System.String addrspace(1)** %loc1
+  store %System.String addrspace(1)* %44, %System.String addrspace(1)** %loc3
+  %45 = load %System.String addrspace(1)** %loc3
+  %46 = ptrtoint %System.String addrspace(1)* %45 to i64
+  %47 = inttoptr i64 %46 to i16*
+  store i16* %47, i16** %loc2
+  %48 = load %System.String addrspace(1)** %loc3
+  %49 = ptrtoint %System.String addrspace(1)* %48 to i64
+  %50 = icmp eq i64 %49, 0
+  br i1 %50, label %57, label %51
+
+; <label>:51                                      ; preds = %41
+  %52 = load i16** %loc2
+  %53 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %54 = bitcast i16* %52 to i8*
+  %55 = getelementptr inbounds i8* %54, i32 %53
+  %56 = bitcast i8* %55 to i16*
+  store i16* %56, i16** %loc2
+  br label %57
+
+; <label>:57                                      ; preds = %41, %51
+  %58 = load i16** %loc2
+  %59 = load i16** %loc0
+  %60 = load i32* %arg3
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, i16*, i32)*)(i16* %58, i16* %59, i32 %60)
+  br label %61
+
+; <label>:61                                      ; preds = %57
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc3
+  br label %62
+
+; <label>:62                                      ; preds = %61
+  %63 = load %System.String addrspace(1)** %loc1
+  store %System.String addrspace(1)* %63, %System.String addrspace(1)** %loc4
+  br label %64
+
+; <label>:64                                      ; preds = %62
+  %65 = load %System.String addrspace(1)** %loc4
+  ret %System.String addrspace(1)* %65
+}
+
+INFO:  jitting method System.Runtime.CompilerServices.RuntimeHelpers::get_OffsetToStringData using LLILCJit
+Successfully read System.Runtime.CompilerServices.RuntimeHelpers.get_OffsetToStringData
+
+define i32 @System.Runtime.CompilerServices.RuntimeHelpers.get_OffsetToStringData() {
+entry:
+  ret i32 12
+}
+
+INFO:  jitting method System.String::wstrcpy using LLILCJit
+Failed to read System.String.wstrcpy[Tail call]
+INFO:  jitting method System.String::Equals using LLILCJit
+Failed to read System.String.Equals[fgMakeSwitch]
+INFO:  jitting method System.Text.StringBuilder::Append using LLILCJit
+Failed to read System.Text.StringBuilder.Append[storeElem]
+INFO:  jitting method System.Text.StringBuilder::AppendHelper using LLILCJit
+Successfully read System.Text.StringBuilder.AppendHelper
+
+define void @System.Text.StringBuilder.AppendHelper(%System.Text.StringBuilder addrspace(1)* %param0, %System.String addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %loc0 = alloca i16*
+  %loc1 = alloca %System.String addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  %0 = load %System.String addrspace(1)** %arg1
+  store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc1
+  %1 = load %System.String addrspace(1)** %loc1
+  %2 = ptrtoint %System.String addrspace(1)* %1 to i64
+  %3 = inttoptr i64 %2 to i16*
+  store i16* %3, i16** %loc0
+  %4 = load %System.String addrspace(1)** %loc1
+  %5 = ptrtoint %System.String addrspace(1)* %4 to i64
+  %6 = icmp eq i64 %5, 0
+  br i1 %6, label %13, label %7
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i16** %loc0
+  %9 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 ()*)()
+  %10 = bitcast i16* %8 to i8*
+  %11 = getelementptr inbounds i8* %10, i32 %9
+  %12 = bitcast i8* %11 to i16*
+  store i16* %12, i16** %loc0
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %7
+  %14 = load %System.Text.StringBuilder addrspace(1)** %this
+  %15 = load i16** %loc0
+  %16 = load %System.String addrspace(1)** %arg1
+  %17 = getelementptr inbounds %System.String addrspace(1)* %16, i32 0, i32 1
+  %18 = load i32 addrspace(1)* %17
+  %19 = call %System.Text.StringBuilder addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.StringBuilder addrspace(1)* (%System.Text.StringBuilder addrspace(1)*, i16*, i32)*)(%System.Text.StringBuilder addrspace(1)* %14, i16* %15, i32 %18)
+  store %System.String addrspace(1)* null, %System.String addrspace(1)** %loc1
+  ret void
+}
+
+INFO:  jitting method System.Text.StringBuilder::Append using LLILCJit
+Successfully read System.Text.StringBuilder.Append
+
+define %System.Text.StringBuilder addrspace(1)* @System.Text.StringBuilder.Append(%System.Text.StringBuilder addrspace(1)* %param0, i16* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i16*
+  %arg2 = alloca i32
+  %loc0 = alloca i32
+  %loc1 = alloca i32
+  %loc2 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i16* %param1, i16** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg2
+  %9 = load %System.Text.StringBuilder addrspace(1)** %this
+  %10 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %9, i32 0, i32 3
+  %11 = load i32 addrspace(1)* %10, align 8
+  %12 = add i32 %8, %11
+  store i32 %12, i32* %loc0
+  %13 = load i32* %loc0
+  %14 = load %System.Text.StringBuilder addrspace(1)** %this
+  %15 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %14, i32 0, i32 1
+  %16 = load %"System.Char[]" addrspace(1)* addrspace(1)* %15, align 8
+  %17 = getelementptr inbounds %"System.Char[]" addrspace(1)* %16, i32 0, i32 1
+  %18 = load i32 addrspace(1)* %17
+  %19 = zext i32 %18 to i64
+  %20 = trunc i64 %19 to i32
+  %21 = icmp sgt i32 %13, %20
+  br i1 %21, label %34, label %22
+
+; <label>:22                                      ; preds = %7
+  %23 = load i16** %arg1
+  %24 = load %System.Text.StringBuilder addrspace(1)** %this
+  %25 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %24, i32 0, i32 1
+  %26 = load %"System.Char[]" addrspace(1)* addrspace(1)* %25, align 8
+  %27 = load %System.Text.StringBuilder addrspace(1)** %this
+  %28 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %27, i32 0, i32 3
+  %29 = load i32 addrspace(1)* %28, align 8
+  %30 = load i32* %arg2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %23, %"System.Char[]" addrspace(1)* %26, i32 %29, i32 %30)
+  %31 = load %System.Text.StringBuilder addrspace(1)** %this
+  %32 = load i32* %loc0
+  %33 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %31, i32 0, i32 3
+  store i32 %32, i32 addrspace(1)* %33
+  br label %93
+
+; <label>:34                                      ; preds = %7
+  %35 = load %System.Text.StringBuilder addrspace(1)** %this
+  %36 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %35, i32 0, i32 1
+  %37 = load %"System.Char[]" addrspace(1)* addrspace(1)* %36, align 8
+  %38 = getelementptr inbounds %"System.Char[]" addrspace(1)* %37, i32 0, i32 1
+  %39 = load i32 addrspace(1)* %38
+  %40 = zext i32 %39 to i64
+  %41 = trunc i64 %40 to i32
+  %42 = load %System.Text.StringBuilder addrspace(1)** %this
+  %43 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %42, i32 0, i32 3
+  %44 = load i32 addrspace(1)* %43, align 8
+  %45 = sub i32 %41, %44
+  store i32 %45, i32* %loc1
+  %46 = load i32* %loc1
+  %47 = icmp sle i32 %46, 0
+  br i1 %47, label %66, label %48
+
+; <label>:48                                      ; preds = %34
+  %49 = load i16** %arg1
+  %50 = load %System.Text.StringBuilder addrspace(1)** %this
+  %51 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %50, i32 0, i32 1
+  %52 = load %"System.Char[]" addrspace(1)* addrspace(1)* %51, align 8
+  %53 = load %System.Text.StringBuilder addrspace(1)** %this
+  %54 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %53, i32 0, i32 3
+  %55 = load i32 addrspace(1)* %54, align 8
+  %56 = load i32* %loc1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %49, %"System.Char[]" addrspace(1)* %52, i32 %55, i32 %56)
+  %57 = load %System.Text.StringBuilder addrspace(1)** %this
+  %58 = load %System.Text.StringBuilder addrspace(1)** %this
+  %59 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %58, i32 0, i32 1
+  %60 = load %"System.Char[]" addrspace(1)* addrspace(1)* %59, align 8
+  %61 = getelementptr inbounds %"System.Char[]" addrspace(1)* %60, i32 0, i32 1
+  %62 = load i32 addrspace(1)* %61
+  %63 = zext i32 %62 to i64
+  %64 = trunc i64 %63 to i32
+  %65 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %57, i32 0, i32 3
+  store i32 %64, i32 addrspace(1)* %65
+  br label %66
+
+; <label>:66                                      ; preds = %34, %48
+  %67 = load i32* %arg2
+  %68 = load i32* %loc1
+  %69 = sub i32 %67, %68
+  store i32 %69, i32* %loc2
+  %70 = load %System.Text.StringBuilder addrspace(1)** %this
+  %71 = load i32* %loc2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %70, i32 %71)
+  %72 = load %System.Text.StringBuilder addrspace(1)** %this
+  %73 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %72, i32 0, i32 3
+  %74 = load i32 addrspace(1)* %73, align 8
+  %75 = icmp eq i32 %74, 0
+  %76 = sext i1 %75 to i32
+  %77 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %78 = trunc i32 %76 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8, %System.String addrspace(1)*)*)(i8 %78, %System.String addrspace(1)* %77)
+  %79 = load i16** %arg1
+  %80 = load i32* %loc1
+  %81 = sext i32 %80 to i64
+  %82 = mul i64 %81, 2
+  %83 = bitcast i16* %79 to i8*
+  %84 = getelementptr inbounds i8* %83, i64 %82
+  %85 = load %System.Text.StringBuilder addrspace(1)** %this
+  %86 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %85, i32 0, i32 1
+  %87 = load %"System.Char[]" addrspace(1)* addrspace(1)* %86, align 8
+  %88 = load i32* %loc2
+  %89 = bitcast i8* %84 to i16*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i16*, %"System.Char[]" addrspace(1)*, i32, i32)*)(i16* %89, %"System.Char[]" addrspace(1)* %87, i32 0, i32 %88)
+  %90 = load %System.Text.StringBuilder addrspace(1)** %this
+  %91 = load i32* %loc2
+  %92 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %90, i32 0, i32 3
+  store i32 %91, i32 addrspace(1)* %92
+  br label %93
+
+; <label>:93                                      ; preds = %22, %66
+  %94 = load %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %94)
+  %95 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %95
+}
+
+INFO:  jitting method System.Text.StringBuilder::ExpandByABlock using LLILCJit
+Failed to read System.Text.StringBuilder.ExpandByABlock[Tail call]
+INFO:  jitting method System.Text.StringBuilder::VerifyClassInvariant using LLILCJit
+Failed to read System.Text.StringBuilder.VerifyClassInvariant[Tail call]
+INFO:  jitting method System.BCLDebug::Correctness using LLILCJit
+Failed to read System.BCLDebug.Correctness[Call needs null check]
+INFO:  jitting method System.BCLDebug::.cctor using LLILCJit
+Failed to read System.BCLDebug..cctor[storeStaticField]
+INFO:  jitting method System.SwitchStructure::.ctor using LLILCJit
+Successfully read System.SwitchStructure..ctor
+
+define void @System.SwitchStructure..ctor(%System.SwitchStructure addrspace(1)* %param0, %System.String addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.SwitchStructure addrspace(1)*
+  %arg1 = alloca %System.String addrspace(1)*
+  %arg2 = alloca i32
+  store %System.SwitchStructure addrspace(1)* %param0, %System.SwitchStructure addrspace(1)** %this
+  store %System.String addrspace(1)* %param1, %System.String addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.SwitchStructure addrspace(1)** %this
+  %1 = load %System.String addrspace(1)** %arg1
+  %2 = getelementptr inbounds %System.SwitchStructure addrspace(1)* %0, i32 0, i32 0
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.String addrspace(1)* addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* addrspace(1)* %2, %System.String addrspace(1)* %1)
+  %3 = load %System.SwitchStructure addrspace(1)** %this
+  %4 = load i32* %arg2
+  %5 = getelementptr inbounds %System.SwitchStructure addrspace(1)* %3, i32 0, i32 1
+  store i32 %4, i32 addrspace(1)* %5
+  ret void
+}
+
+INFO:  jitting method System.BCLDebug::CheckRegistry using LLILCJit
+Failed to read System.BCLDebug.CheckRegistry[Call needs null check]
+INFO:  jitting method System.Text.StringBuilder::Append using LLILCJit
+Failed to read System.Text.StringBuilder.Append[storeElem]
+INFO:  jitting method System.Text.StringBuilder::Append using LLILCJit
+Failed to read System.Text.StringBuilder.Append[storeElem]
+INFO:  jitting method System.Text.StringBuilder::Remove using LLILCJit
+Successfully read System.Text.StringBuilder.Remove
+
+define %System.Text.StringBuilder addrspace(1)* @System.Text.StringBuilder.Remove(%System.Text.StringBuilder addrspace(1)* %param0, i32 %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  %arg1 = alloca i32
+  %arg2 = alloca i32
+  %loc0 = alloca %System.Text.StringBuilder addrspace(1)*
+  %loc1 = alloca i32
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  store i32 %param1, i32* %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load i32* %arg2
+  %1 = icmp sge i32 %0, 0
+  br i1 %1, label %7, label %2
+
+; <label>:2                                       ; preds = %entry
+  %3 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %4 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %5 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %4)
+  %6 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6, %System.String addrspace(1)* %3, %System.String addrspace(1)* %5)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %6) #0
+  unreachable
+
+; <label>:7                                       ; preds = %entry
+  %8 = load i32* %arg1
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %15, label %10
+
+; <label>:10                                      ; preds = %7
+  %11 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %12)
+  %14 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14, %System.String addrspace(1)* %11, %System.String addrspace(1)* %13)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %14) #0
+  unreachable
+
+; <label>:15                                      ; preds = %7
+  %16 = load i32* %arg2
+  %17 = load %System.Text.StringBuilder addrspace(1)** %this
+  %18 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %17)
+  %19 = load i32* %arg1
+  %20 = sub i32 %18, %19
+  %21 = icmp sle i32 %16, %20
+  br i1 %21, label %27, label %22
+
+; <label>:22                                      ; preds = %15
+  %23 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %24 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %25 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %24)
+  %26 = call %System.ArgumentOutOfRangeException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentOutOfRangeException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26, %System.String addrspace(1)* %23, %System.String addrspace(1)* %25)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentOutOfRangeException addrspace(1)*)*)(%System.ArgumentOutOfRangeException addrspace(1)* %26) #0
+  unreachable
+
+; <label>:27                                      ; preds = %15
+  %28 = load %System.Text.StringBuilder addrspace(1)** %this
+  %29 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (%System.Text.StringBuilder addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %28)
+  %30 = load i32* %arg2
+  %31 = icmp ne i32 %29, %30
+  br i1 %31, label %38, label %32
+
+; <label>:32                                      ; preds = %27
+  %33 = load i32* %arg1
+  %34 = icmp ne i32 %33, 0
+  br i1 %34, label %38, label %35
+
+; <label>:35                                      ; preds = %32
+  %36 = load %System.Text.StringBuilder addrspace(1)** %this
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32)*)(%System.Text.StringBuilder addrspace(1)* %36, i32 0)
+  %37 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %37
+
+; <label>:38                                      ; preds = %27, %32
+  %39 = load i32* %arg2
+  %40 = icmp sle i32 %39, 0
+  br i1 %40, label %47, label %41
+
+; <label>:41                                      ; preds = %38
+  %42 = load %System.Text.StringBuilder addrspace(1)** %this
+  %43 = load i32* %arg1
+  %44 = load i32* %arg2
+  %45 = addrspacecast %System.Text.StringBuilder addrspace(1)** %loc0 to %System.Text.StringBuilder addrspace(1)* addrspace(1)*
+  %46 = addrspacecast i32* %loc1 to i32 addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.StringBuilder addrspace(1)*, i32, i32, %System.Text.StringBuilder addrspace(1)* addrspace(1)*, i32 addrspace(1)*)*)(%System.Text.StringBuilder addrspace(1)* %42, i32 %43, i32 %44, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %45, i32 addrspace(1)* %46)
+  br label %47
+
+; <label>:47                                      ; preds = %38, %41
+  %48 = load %System.Text.StringBuilder addrspace(1)** %this
+  ret %System.Text.StringBuilder addrspace(1)* %48
+}
+
+INFO:  jitting method System.Text.StringBuilder::get_Length using LLILCJit
+Successfully read System.Text.StringBuilder.get_Length
+
+define i32 @System.Text.StringBuilder.get_Length(%System.Text.StringBuilder addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Text.StringBuilder addrspace(1)*
+  store %System.Text.StringBuilder addrspace(1)* %param0, %System.Text.StringBuilder addrspace(1)** %this
+  %0 = load %System.Text.StringBuilder addrspace(1)** %this
+  %1 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %0, i32 0, i32 4
+  %2 = load i32 addrspace(1)* %1, align 8
+  %3 = load %System.Text.StringBuilder addrspace(1)** %this
+  %4 = getelementptr inbounds %System.Text.StringBuilder addrspace(1)* %3, i32 0, i32 3
+  %5 = load i32 addrspace(1)* %4, align 8
+  %6 = add i32 %2, %5
+  ret i32 %6
+}
+
+INFO:  jitting method System.Text.StringBuilder::Remove using LLILCJit
+Failed to read System.Text.StringBuilder.Remove[storePrimitiveType]
+INFO:  jitting method System.Text.StringBuilder::ThreadSafeCopy using LLILCJit
+Failed to read System.Text.StringBuilder.ThreadSafeCopy[loadElemA]
+INFO:  jitting method System.Text.StringBuilder::ToString using LLILCJit
+Failed to read System.Text.StringBuilder.ToString[loadElemA]
+INFO:  jitting method System.Buffer::_Memmove using LLILCJit
+Failed to read System.Buffer._Memmove[Tail call]
+INFO:  jitting method System.AppDomain::SetDataHelper using LLILCJit
+Failed to read System.AppDomain.SetDataHelper[Call needs null check]
+INFO:  jitting method System.AppDomain::get_LocalStore using LLILCJit
+Successfully read System.AppDomain.get_LocalStore
+
+define %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* @System.AppDomain.get_LocalStore(%System.AppDomain addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomain addrspace(1)*
+  store %System.AppDomain addrspace(1)* %param0, %System.AppDomain addrspace(1)** %this
+  %0 = load %System.AppDomain addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomain addrspace(1)* %0, i32 0, i32 2
+  %2 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp eq %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.AppDomain addrspace(1)** %this
+  %6 = getelementptr inbounds %System.AppDomain addrspace(1)* %5, i32 0, i32 2
+  %7 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %6, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %7
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.AppDomain addrspace(1)** %this
+  %10 = call %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10)
+  %11 = bitcast %"System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]" addrspace(1)* %10 to %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*
+  %12 = getelementptr inbounds %System.AppDomain addrspace(1)* %9, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)*)*)(%"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %12, %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %11)
+  %13 = load %System.AppDomain addrspace(1)** %this
+  %14 = getelementptr inbounds %System.AppDomain addrspace(1)* %13, i32 0, i32 2
+  %15 = load %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* addrspace(1)* %14, align 8
+  ret %"System.Collections.Generic.Dictionary`2[System.String,System.Object[]]" addrspace(1)* %15
+}
+
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Tail call]
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::.ctor using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]..ctor[Call HasTypeArg]
+INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::get_Default using LLILCJit
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].get_Default[Call HasTypeArg]
+INFO:  jitting method System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon]::CreateComparer using LLILCJit
+Failed to read System.Collections.Generic.EqualityComparer`1[__Canon][System.__Canon].CreateComparer[fgMakeSwitch]
+INFO:  jitting method System.RuntimeType::IsAssignableFrom using LLILCJit
+Failed to read System.RuntimeType.IsAssignableFrom[Tail call]
+INFO:  jitting method System.RuntimeType::get_UnderlyingSystemType using LLILCJit
+Successfully read System.RuntimeType.get_UnderlyingSystemType
+
+define %System.Type addrspace(1)* @System.RuntimeType.get_UnderlyingSystemType(%System.RuntimeType addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.RuntimeType addrspace(1)*
+  store %System.RuntimeType addrspace(1)* %param0, %System.RuntimeType addrspace(1)** %this
+  %0 = load %System.RuntimeType addrspace(1)** %this
+  %1 = bitcast %System.RuntimeType addrspace(1)* %0 to %System.Type addrspace(1)*
+  ret %System.Type addrspace(1)* %1
+}
+
+INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::.ctor using LLILCJit
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]..ctor[Tail call]
+INFO:  jitting method System.Collections.HashHelpers::.cctor using LLILCJit
+Failed to read System.Collections.HashHelpers..cctor[storeStaticField]
+INFO:  jitting method System.String::UseRandomizedHashing using LLILCJit
+Failed to read System.String.UseRandomizedHashing[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+INFO:  jitting method System.Object::.ctor using LLILCJit
+Successfully read System.Object..ctor
+
+define void @System.Object..ctor(%System.Object addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Object addrspace(1)*
+  store %System.Object addrspace(1)* %param0, %System.Object addrspace(1)** %this
+  ret void
+}
+
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::System.Collections.ICollection.get_SyncRoot using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].System.Collections.ICollection.get_SyncRoot[genNullCheck]
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::TryGetValue using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].TryGetValue[loadElemA]
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::FindEntry using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].FindEntry[non-const derefAddress]
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Insert using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Insert[non-const derefAddress]
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Initialize using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Initialize[non-const derefAddress]
+INFO:  jitting method System.Collections.HashHelpers::GetPrime using LLILCJit
+Failed to read System.Collections.HashHelpers.GetPrime[loadElem]
+INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::GetHashCode using LLILCJit
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].GetHashCode[Tail call]
+INFO:  jitting method System.String::GetHashCode using LLILCJit
+Failed to read System.String.GetHashCode[Tail call]
+INFO:  jitting method System.IO.Path::NormalizePath using LLILCJit
+Failed to read System.IO.Path.NormalizePath[Tail call]
+INFO:  jitting method System.String::op_Equality using LLILCJit
+Failed to read System.String.op_Equality[Tail call]
+INFO:  jitting method System.Text.StringBuilder::.ctor using LLILCJit
+Failed to read System.Text.StringBuilder..ctor[Tail call]
+INFO:  jitting method System.Collections.HashHelpers::ExpandPrime using LLILCJit
+Failed to read System.Collections.HashHelpers.ExpandPrime[Tail call]
+INFO:  jitting method System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]::Resize using LLILCJit
+Failed to read System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon].Resize[non-const derefAddress]
+INFO:  jitting method System.AppDomain::CreateAppDomainManager using LLILCJit
+Failed to read System.AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
+INFO:  jitting method System.AppDomain::GetData using LLILCJit
+Failed to read System.AppDomain.GetData[Call needs null check]
+INFO:  jitting method System.AppDomainSetup::Locate using LLILCJit
+Successfully read System.AppDomainSetup.Locate
+
+define i32 @System.AppDomainSetup.Locate(%System.String addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.String addrspace(1)*
+  store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
+  %0 = load %System.String addrspace(1)** %arg0
+  %1 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %0)
+  %2 = zext i8 %1 to i32
+  %3 = icmp eq i32 %2, 0
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret i32 -1
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = getelementptr inbounds %System.String addrspace(1)* %6, i32 0, i32 2, i32 0
+  %8 = load i16 addrspace(1)* %7
+  %9 = zext i16 %8 to i32
+  %10 = icmp eq i32 65, %9
+  %11 = sext i1 %10 to i32
+  %12 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %13 = trunc i32 %11 to i8
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8, %System.String addrspace(1)*)*)(i8 %13, %System.String addrspace(1)* %12)
+  %14 = load %System.String addrspace(1)** %arg0
+  %15 = getelementptr inbounds %System.String addrspace(1)* %14, i32 0, i32 2, i32 0
+  %16 = load i16 addrspace(1)* %15
+  %17 = zext i16 %16 to i32
+  %18 = icmp ne i32 %17, 65
+  br i1 %18, label %26, label %19
+
+; <label>:19                                      ; preds = %5
+  %20 = load %System.String addrspace(1)** %arg0
+  %21 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %22 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %20, %System.String addrspace(1)* %21)
+  %23 = zext i8 %22 to i32
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %26, label %25
+
+; <label>:25                                      ; preds = %19
+  ret i32 0
+
+; <label>:26                                      ; preds = %5, %19
+  ret i32 -1
+}
+
+INFO:  jitting method System.AppDomainSetup::get_LoaderOptimizationKey using LLILCJit
+Successfully read System.AppDomainSetup.get_LoaderOptimizationKey
+
+define %System.String addrspace(1)* @System.AppDomainSetup.get_LoaderOptimizationKey() {
+entry:
+  %0 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  ret %System.String addrspace(1)* %0
+}
+
+INFO:  jitting method System.String::Equals using LLILCJit
+Failed to read System.String.Equals[Tail call]
+INFO:  jitting method System.Threading.Monitor::Enter using LLILCJit
+Failed to read System.Threading.Monitor.Enter[Tail call]
+INFO:  jitting method System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]::Equals using LLILCJit
+Failed to read System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon].Equals[non-const derefAddress]
+INFO:  jitting method System.AppDomain::SetupBindingPaths using LLILCJit
+Failed to read System.AppDomain.SetupBindingPaths[Tail call]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+INFO:  jitting method System.AppDomain::GetAppDomainManagerType using LLILCJit
+Failed to read System.AppDomain.GetAppDomainManagerType[Return refany or value class]
+INFO:  jitting method System.AppDomain::GetNativeHandle using LLILCJit
+Failed to read System.AppDomain.GetNativeHandle[genNullCheck]
+INFO:  jitting method System.Runtime.CompilerServices.JitHelpers::UnsafeCastToStackPointer using LLILCJit
+Failed to read System.Runtime.CompilerServices.JitHelpers.UnsafeCastToStackPointer[Call HasTypeArg]
+INFO:  jitting method System.AppDomain::InitializeCompatibilityFlags using LLILCJit
+Failed to read System.AppDomain.InitializeCompatibilityFlags[Call needs null check]
+INFO:  jitting method System.CompatibilitySwitches::InitializeSwitches using LLILCJit
+Failed to read System.CompatibilitySwitches.InitializeSwitches[storeStaticField]
+INFO:  jitting method System.CompatibilitySwitches::IsCompatibilitySwitchSet using LLILCJit
+Failed to read System.CompatibilitySwitches.IsCompatibilitySwitchSet[Call needs null check]
+INFO:  jitting method System.AppDomain::IsCompatibilitySwitchSet using LLILCJit
+Failed to read System.AppDomain.IsCompatibilitySwitchSet[Call needs null check]
+INFO:  jitting method System.AppDomain::InitializeDomainSecurity using LLILCJit
+Failed to read System.AppDomain.InitializeDomainSecurity[Call needs null check]
+INFO:  jitting method System.AppDomainSetup::InternalGetApplicationTrust using LLILCJit
+Successfully read System.AppDomainSetup.InternalGetApplicationTrust
+
+define %System.Security.Policy.ApplicationTrust addrspace(1)* @System.AppDomainSetup.InternalGetApplicationTrust(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)** %this
+  %1 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 5
+  %2 = load %System.String addrspace(1)* addrspace(1)* %1, align 8
+  %3 = icmp ne %System.String addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* null
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.AppDomainSetup addrspace(1)** %this
+  %7 = getelementptr inbounds %System.AppDomainSetup addrspace(1)* %6, i32 0, i32 5
+  %8 = load %System.String addrspace(1)* addrspace(1)* %7, align 8
+  %9 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %8)
+  %10 = call %System.Security.Policy.ApplicationTrust addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.Policy.ApplicationTrust addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %10, %System.Security.PermissionSet addrspace(1)* %9)
+  ret %System.Security.Policy.ApplicationTrust addrspace(1)* %10
+}
+
+INFO:  jitting method System.Security.NamedPermissionSet::GetBuiltInSet using LLILCJit
+Failed to read System.Security.NamedPermissionSet.GetBuiltInSet[Call needs null check]
+INFO:  jitting method System.Security.PermissionSet::.ctor using LLILCJit
+Failed to read System.Security.PermissionSet..ctor[Tail call]
+INFO:  jitting method System.Security.Policy.ApplicationTrust::.ctor using LLILCJit
+Successfully read System.Security.Policy.ApplicationTrust..ctor
+
+define void @System.Security.Policy.ApplicationTrust..ctor(%System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1) {
+entry:
+  %this = alloca %System.Security.Policy.ApplicationTrust addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.ApplicationTrust addrspace(1)* %param0, %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  %0 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.ApplicationTrust addrspace(1)* %0 to %System.Security.Policy.EvidenceBase addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.EvidenceBase addrspace(1)*)*)(%System.Security.Policy.EvidenceBase addrspace(1)* %1)
+  %2 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %3 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.Policy.ApplicationTrust addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.Policy.ApplicationTrust addrspace(1)* %2, %System.Security.PermissionSet addrspace(1)* %3)
+  %4 = load %System.Security.Policy.ApplicationTrust addrspace(1)** %this
+  %5 = call %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
+  %6 = call %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* (%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.List`1[System.__Canon]" addrspace(1)* %5)
+  %7 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6 to %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*
+  %8 = getelementptr inbounds %System.Security.Policy.ApplicationTrust addrspace(1)* %4, i32 0, i32 2
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.Security.Policy.StrongName]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method System.Security.Policy.EvidenceBase::.ctor using LLILCJit
+Failed to read System.Security.Policy.EvidenceBase..ctor[Tail call]
+INFO:  jitting method System.Security.Policy.ApplicationTrust::InitDefaultGrantSet using LLILCJit
+Failed to read System.Security.Policy.ApplicationTrust.InitDefaultGrantSet[Tail call]
+INFO:  jitting method System.Security.Policy.PolicyStatement::.ctor using LLILCJit
+Successfully read System.Security.Policy.PolicyStatement..ctor
+
+define void @System.Security.Policy.PolicyStatement..ctor(%System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)* %param1, i32 %param2) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %arg1 = alloca %System.Security.PermissionSet addrspace(1)*
+  %arg2 = alloca i32
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.PermissionSet addrspace(1)* %param1, %System.Security.PermissionSet addrspace(1)** %arg1
+  store i32 %param2, i32* %arg2
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %1 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %3 = icmp ne %System.Security.PermissionSet addrspace(1)* %2, null
+  br i1 %3, label %8, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %6 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, i8)*)(%System.Security.PermissionSet addrspace(1)* %6, i8 0)
+  %7 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %5, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %7, %System.Security.PermissionSet addrspace(1)* %6)
+  br label %22
+
+; <label>:8                                       ; preds = %entry
+  %9 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %10 = load %System.Security.PermissionSet addrspace(1)** %arg1
+  %11 = bitcast %System.Security.PermissionSet addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64 addrspace(1)* %11
+  %13 = add i64 %12, 80
+  %14 = inttoptr i64 %13 to i64*
+  %15 = load i64* %14
+  %16 = add i64 %15, 40
+  %17 = inttoptr i64 %16 to i64*
+  %18 = load i64* %17
+  %19 = inttoptr i64 %18 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %20 = call %System.Security.PermissionSet addrspace(1)* %19(%System.Security.PermissionSet addrspace(1)* %10)
+  %21 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %9, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)* addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* addrspace(1)* %21, %System.Security.PermissionSet addrspace(1)* %20)
+  br label %22
+
+; <label>:22                                      ; preds = %4, %8
+  %23 = load i32* %arg2
+  %24 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (i32)*)(i32 %23)
+  %25 = zext i8 %24 to i32
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %31, label %27
+
+; <label>:27                                      ; preds = %22
+  %28 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %29 = load i32* %arg2
+  %30 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %28, i32 0, i32 2
+  store i32 %29, i32 addrspace(1)* %30
+  br label %31
+
+; <label>:31                                      ; preds = %22, %27
+  ret void
+}
+
+INFO:  jitting method System.Security.PermissionSet::Copy using LLILCJit
+Successfully read System.Security.PermissionSet.Copy
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.PermissionSet.Copy(%System.Security.PermissionSet addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.PermissionSet addrspace(1)* %param0, %System.Security.PermissionSet addrspace(1)** %this
+  %0 = load %System.Security.PermissionSet addrspace(1)** %this
+  %1 = call %System.Security.PermissionSet addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Security.PermissionSet addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)*)*)(%System.Security.PermissionSet addrspace(1)* %1, %System.Security.PermissionSet addrspace(1)* %0)
+  ret %System.Security.PermissionSet addrspace(1)* %1
+}
+
+INFO:  jitting method System.Security.PermissionSet::.ctor using LLILCJit
+Failed to read System.Security.PermissionSet..ctor[Tail call]
+INFO:  jitting method System.Security.Policy.PolicyStatement::ValidProperties using LLILCJit
+Successfully read System.Security.Policy.PolicyStatement.ValidProperties
+
+define i8 @System.Security.Policy.PolicyStatement.ValidProperties(i32 %param0) {
+entry:
+  %arg0 = alloca i32
+  store i32 %param0, i32* %arg0
+  %0 = load i32* %arg0
+  %1 = and i32 %0, -4
+  %2 = icmp ne i32 %1, 0
+  br i1 %2, label %4, label %3
+
+; <label>:3                                       ; preds = %entry
+  ret i8 1
+
+; <label>:4                                       ; preds = %entry
+  %5 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %6 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %5)
+  %7 = call %System.ArgumentException addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.ArgumentException addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*, %System.String addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %7, %System.String addrspace(1)* %6)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.ArgumentException addrspace(1)*)*)(%System.ArgumentException addrspace(1)* %7) #0
+  unreachable
+}
+
+INFO:  jitting method System.Security.Policy.ApplicationTrust::set_DefaultGrantSet using LLILCJit
+Failed to read System.Security.Policy.ApplicationTrust.set_DefaultGrantSet[Call needs null check]
+INFO:  jitting method System.Security.Policy.PolicyStatement::get_PermissionSet using LLILCJit
+Successfully read System.Security.Policy.PolicyStatement.get_PermissionSet
+
+define %System.Security.PermissionSet addrspace(1)* @System.Security.Policy.PolicyStatement.get_PermissionSet(%System.Security.Policy.PolicyStatement addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc0 = alloca %System.Security.Policy.PolicyStatement addrspace(1)*
+  %loc1 = alloca i8
+  %loc2 = alloca %System.Security.PermissionSet addrspace(1)*
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %param0, %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store i8 0, i8* %loc1
+  %0 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  store %System.Security.Policy.PolicyStatement addrspace(1)* %0, %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %1 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %2 = addrspacecast i8* %loc1 to i8 addrspace(1)*
+  %3 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %1 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*, i8 addrspace(1)*)*)(%System.Object addrspace(1)* %3, i8 addrspace(1)* %2)
+  %4 = load %System.Security.Policy.PolicyStatement addrspace(1)** %this
+  %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement addrspace(1)* %4, i32 0, i32 1
+  %6 = load %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64 addrspace(1)* %7
+  %9 = add i64 %8, 80
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load i64* %10
+  %12 = add i64 %11, 40
+  %13 = inttoptr i64 %12 to i64*
+  %14 = load i64* %13
+  %15 = inttoptr i64 %14 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
+  %16 = call %System.Security.PermissionSet addrspace(1)* %15(%System.Security.PermissionSet addrspace(1)* %6)
+  store %System.Security.PermissionSet addrspace(1)* %16, %System.Security.PermissionSet addrspace(1)** %loc2
+  br label %17
+
+; <label>:17                                      ; preds = %entry
+  %18 = load i8* %loc1
+  %19 = zext i8 %18 to i32
+  %20 = icmp eq i32 %19, 0
+  br i1 %20, label %24, label %21
+
+; <label>:21                                      ; preds = %17
+  %22 = load %System.Security.Policy.PolicyStatement addrspace(1)** %loc0
+  %23 = bitcast %System.Security.Policy.PolicyStatement addrspace(1)* %22 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %23)
+  br label %24
+
+; <label>:24                                      ; preds = %17, %21
+  br label %25
+
+; <label>:25                                      ; preds = %24
+  %26 = load %System.Security.PermissionSet addrspace(1)** %loc2
+  ret %System.Security.PermissionSet addrspace(1)* %26
+}
+
+INFO:  jitting method System.Security.SecurityManager::GetSpecialFlags using LLILCJit
+Failed to read System.Security.SecurityManager.GetSpecialFlags[Call needs null check]
+INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::.ctor using LLILCJit
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon]..ctor[non-const derefAddress]
+INFO:  jitting method System.Collections.Generic.List`1[__Canon][System.__Canon]::AsReadOnly using LLILCJit
+Failed to read System.Collections.Generic.List`1[__Canon][System.__Canon].AsReadOnly[non-const derefAddress]
+INFO:  jitting method System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]::.ctor using LLILCJit
+Successfully read System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor
+
+define void @"System.Collections.ObjectModel.ReadOnlyCollection`1[__Canon][System.__Canon]..ctor"(%"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %param1) {
+entry:
+  %this = alloca %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)*
+  %arg1 = alloca %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*
+  store %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %param0, %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  store %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %param1, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %0 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  %1 = bitcast %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %0 to %System.Object addrspace(1)*
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)*)*)(%System.Object addrspace(1)* %1)
+  %2 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %3 = icmp ne %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %2, null
+  br i1 %3, label %5, label %4
+
+; <label>:4                                       ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i32)*)(i32 7)
+  br label %5
+
+; <label>:5                                       ; preds = %entry, %4
+  %6 = load %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)** %this
+  %7 = load %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)** %arg1
+  %8 = getelementptr inbounds %"System.Collections.ObjectModel.ReadOnlyCollection`1[System.__Canon]" addrspace(1)* %6, i32 0, i32 1
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)*, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)*)*)(%"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* addrspace(1)* %8, %"System.Collections.Generic.IList`1[System.__Canon]" addrspace(1)* %7)
+  ret void
+}
+
+INFO:  jitting method System.AppDomain::SetupDomainSecurityForHomogeneousDomain using LLILCJit
+Failed to read System.AppDomain.SetupDomainSecurityForHomogeneousDomain[Call needs null check]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+INFO:  jitting method System.AppDomain::SetupDomainSecurity using LLILCJit
+Failed to read System.AppDomain.SetupDomainSecurity[Return refany or value class]
+INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+INFO:  jitting method System.AppDomain::RunInitializer using LLILCJit
+Failed to read System.AppDomain.RunInitializer[Call needs null check]
+INFO:  jitting method <Module>::main using LLILCJit
+Successfully read <Module>.main
+
+define i32 @"<Module>.main"() {
+entry:
+  %0 = call i32 inttoptr (i64 NORMALIZED_ADDRESS to i32 (i32, i32)*)(i32 43689, i32 0)
+  %1 = add i32 %0, 1
+  ret i32 %1
+}
+
+INFO:  jitting method <Module>::test using LLILCJit
+Successfully read <Module>.test
+
+define i32 @"<Module>.test"(i32 %param0, i32 %param1) {
+entry:
+  %arg0 = alloca i32
+  %arg1 = alloca i32
+  store i32 %param0, i32* %arg0
+  store i32 %param1, i32* %arg1
+  %0 = load i32* %arg1
+  %1 = load i32* %arg0
+  %2 = load i32* %arg1
+  %3 = icmp eq i32 %1, %2
+  br i1 %3, label %10, label %4
+
+; <label>:4                                       ; preds = %entry
+  %5 = load i32* %arg0
+  %6 = load i32* %arg1
+  %7 = icmp slt i32 %5, %6
+  br i1 %7, label %12, label %8
+
+; <label>:8                                       ; preds = %4
+  %9 = load i32* %arg0
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %8
+  %11 = phi i32 [ %0, %entry ], [ %9, %8 ]
+  ret i32 %11
+
+; <label>:12                                      ; preds = %4
+  ret i32 %0
+}
+


### PR DESCRIPTION
@kyulee1 ran into verification failure on System.Buffer.Memmove (empty block). I created a simple repro. The important parts of the repro:
- a ret instruction is the target of a branch;
- the ret instruction is preceded by a non-control-flow instruction;
- the instruction after the ret is a target of a branch.

There were two issues with the code: 
- The start offset of the blocks immediately following ret was set incorrectly.
- When splitting an empty block, it was placed at the back of the list of basic blocks instead of after the block being split.

I fixed both issues and added an assert that branch targets are always adjusted to the basic blocks with the correct offset.

Closes #93 
