### PR TITLE
Fix Identifier Names and Spacing of PAL files 

### DIFF
--- a/include/Pal/LLILCPal.h
+++ b/include/Pal/LLILCPal.h
@@ -3,8 +3,8 @@
 // LLILC
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. 
-// See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
 //
@@ -37,41 +37,38 @@
 #define PAL_SEH_RESTORE_GUARD_PAGE
 
 #define PAL_TRY_NAKED                                                          \
-    {                                                                          \
-        bool __exHandled; __exHandled = false;                                 \
-        DWORD __exCode; __exCode = 0;                                          \
-        SCAN_EHMARKER();                                                       \
-        __try                                                                  \
-        {                                                                      \
-            SCAN_EHMARKER_TRY();
+  {                                                                            \
+    bool __exHandled;                                                          \
+    __exHandled = false;                                                       \
+    DWORD __exCode;                                                            \
+    __exCode = 0;                                                              \
+    SCAN_EHMARKER();                                                           \
+    __try {                                                                    \
+      SCAN_EHMARKER_TRY();
 
 #define PAL_EXCEPT_NAKED(Disposition)                                          \
-        }                                                                      \
-        __except(__exCode = GetExceptionCode(), Disposition)                   \
-        {                                                                      \
-            __exHandled = true;                                                \
-            SCAN_EHMARKER_CATCH();                                             \
-            PAL_SEH_RESTORE_GUARD_PAGE
+  }                                                                            \
+  __except (__exCode = GetExceptionCode(), Disposition) {                      \
+    __exHandled = true;                                                        \
+    SCAN_EHMARKER_CATCH();                                                     \
+  PAL_SEH_RESTORE_GUARD_PAGE
 
 #define PAL_EXCEPT_FILTER_NAKED(pfnFilter, param)                              \
-        }                                                                      \
-        __except(__exCode = GetExceptionCode(),                                \
-                 pfnFilter(GetExceptionInformation(), param))                  \
-        {                                                                      \
-            __exHandled = true;                                                \
-            SCAN_EHMARKER_CATCH();                                             \
-            PAL_SEH_RESTORE_GUARD_PAGE
+  }                                                                            \
+  __except (__exCode = GetExceptionCode(),                                     \
+            pfnFilter(GetExceptionInformation(), param)) {                     \
+    __exHandled = true;                                                        \
+    SCAN_EHMARKER_CATCH();                                                     \
+  PAL_SEH_RESTORE_GUARD_PAGE
 
 #define PAL_FINALLY_NAKED                                                      \
-        }                                                                      \
-        __finally                                                              \
-        {                                                                      \
+  }                                                                            \
+  __finally {
 
 #define PAL_ENDTRY_NAKED                                                       \
-        }                                                                      \
-        PAL_ENDTRY_NAKED_DBG                                                   \
-    }                                                                          \
-
+  }                                                                            \
+  PAL_ENDTRY_NAKED_DBG                                                         \
+  }
 
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE)
 //
@@ -80,82 +77,83 @@
 // accessing any local variables and arguments.
 //
 #define PAL_TRY(__ParamType, __paramDef, __paramRef)                           \
-{                                                                              \
+  {                                                                            \
     __ParamType __param = __paramRef;                                          \
     __ParamType __paramToPassToFilter = __paramRef;                            \
-    class __Body                                                               \
-    {                                                                          \
+    class __Body {                                                             \
     public:                                                                    \
-        static void run(__ParamType __paramDef)                                \
-    {                                                                          \
-        PAL_TRY_HANDLER_DBG_BEGIN
- 
+      static void run(__ParamType __paramDef) {                                \
+      PAL_TRY_HANDLER_DBG_BEGIN
+
 #define PAL_EXCEPT(Disposition)                                                \
-            PAL_TRY_HANDLER_DBG_END                                            \
-        }                                                                      \
-    };                                                                         \
-        PAL_TRY_NAKED                                                          \
-    __Body::run(__param);                                                      \
-    PAL_EXCEPT_NAKED(Disposition)
+  PAL_TRY_HANDLER_DBG_END                                                      \
+  }                                                                            \
+  }                                                                            \
+  ;                                                                            \
+  PAL_TRY_NAKED                                                                \
+  __Body::run(__param);                                                        \
+  PAL_EXCEPT_NAKED(Disposition)
 
 #define PAL_EXCEPT_FILTER(pfnFilter)                                           \
-            PAL_TRY_HANDLER_DBG_END                                            \
-        }                                                                      \
-    };                                                                         \
-    PAL_TRY_NAKED                                                              \
-    __Body::run(__param);                                                      \
-    PAL_EXCEPT_FILTER_NAKED(pfnFilter, __paramToPassToFilter)
+  PAL_TRY_HANDLER_DBG_END                                                      \
+  }                                                                            \
+  }                                                                            \
+  ;                                                                            \
+  PAL_TRY_NAKED                                                                \
+  __Body::run(__param);                                                        \
+  PAL_EXCEPT_FILTER_NAKED(pfnFilter, __paramToPassToFilter)
 
 #define PAL_FINALLY                                                            \
-            PAL_TRY_HANDLER_DBG_END                                            \
-        }                                                                      \
-    };                                                                         \
-    PAL_TRY_NAKED                                                              \
-    __Body::run(__param);                                                      \
-    PAL_FINALLY_NAKED
+  PAL_TRY_HANDLER_DBG_END                                                      \
+  }                                                                            \
+  }                                                                            \
+  ;                                                                            \
+  PAL_TRY_NAKED                                                                \
+  __Body::run(__param);                                                        \
+  PAL_FINALLY_NAKED
 
 #define PAL_ENDTRY                                                             \
-    PAL_ENDTRY_NAKED                                                           \
-}
+  PAL_ENDTRY_NAKED                                                             \
+  }
 
 #else // _DEBUG
 
 #define PAL_TRY(__ParamType, __paramDef, __paramRef)                           \
-{                                                                              \
+  {                                                                            \
     __ParamType __param = __paramRef;                                          \
     __ParamType __paramDef = __param;                                          \
     PAL_TRY_NAKED                                                              \
-    PAL_TRY_HANDLER_DBG_BEGIN
+  PAL_TRY_HANDLER_DBG_BEGIN
 
 #define PAL_EXCEPT(Disposition)                                                \
-        PAL_TRY_HANDLER_DBG_END                                                \
-        PAL_EXCEPT_NAKED(Disposition)
+  PAL_TRY_HANDLER_DBG_END                                                      \
+  PAL_EXCEPT_NAKED(Disposition)
 
 #define PAL_EXCEPT_FILTER(pfnFilter)                                           \
-        PAL_TRY_HANDLER_DBG_END                                                \
-        PAL_EXCEPT_FILTER_NAKED(pfnFilter, __param)
+  PAL_TRY_HANDLER_DBG_END                                                      \
+  PAL_EXCEPT_FILTER_NAKED(pfnFilter, __param)
 
 #define PAL_FINALLY                                                            \
-        PAL_TRY_HANDLER_DBG_END                                                \
-        PAL_FINALLY_NAKED
+  PAL_TRY_HANDLER_DBG_END                                                      \
+  PAL_FINALLY_NAKED
 
 #define PAL_ENDTRY                                                             \
-    PAL_ENDTRY_NAKED                                                           \
-    }
+  PAL_ENDTRY_NAKED                                                             \
+  }
 
 #endif // _DEBUG
 
-#define PAL_TRY_HANDLER_DBG_BEGIN                   ANNOTATION_TRY_BEGIN;
-#define PAL_TRY_HANDLER_DBG_BEGIN_DLLMAIN(_reason)  ANNOTATION_TRY_BEGIN;
-#define PAL_TRY_HANDLER_DBG_END                     ANNOTATION_TRY_END;
-#define PAL_ENDTRY_NAKED_DBG                                                          
+#define PAL_TRY_HANDLER_DBG_BEGIN ANNOTATION_TRY_BEGIN;
+#define PAL_TRY_HANDLER_DBG_BEGIN_DLLMAIN(_reason) ANNOTATION_TRY_BEGIN;
+#define PAL_TRY_HANDLER_DBG_END ANNOTATION_TRY_END;
+#define PAL_ENDTRY_NAKED_DBG
 
 #else // defined(_MSC_VER)
 
 // SAL
 #define _In_
 #define _Out_opt_
-#define _Out_writes_to_opt_(size,count)
+#define _Out_writes_to_opt_(size, count)
 #define __out_ecount(count)
 #define __inout_ecount(count)
 #define __deref_inout_ecount(count)
@@ -189,10 +187,10 @@ extern "C" {
 
 #define STDAPICALLTYPE __stdcall
 
-#define STDMETHOD(method)       virtual HRESULT STDMETHODCALLTYPE method
-#define STDMETHOD_(type,method) virtual type STDMETHODCALLTYPE method
+#define STDMETHOD(method) virtual HRESULT STDMETHODCALLTYPE method
+#define STDMETHOD_(type, method) virtual type STDMETHODCALLTYPE method
 
-#define STDAPI        EXTERN_C HRESULT STDAPICALLTYPE
+#define STDAPI EXTERN_C HRESULT STDAPICALLTYPE
 #define STDAPI_(type) EXTERN_C type STDAPICALLTYPE
 
 #define PURE = 0
@@ -200,7 +198,7 @@ extern "C" {
 #if defined(__GNUC__)
 #define DECLSPEC_NOVTABLE
 #define DECLSPEC_IMPORT
-#define DECLSPEC_SELECTANY  __attribute__((weak))
+#define DECLSPEC_SELECTANY __attribute__((weak))
 #define SELECTANY extern __attribute__((weak))
 #else
 #define DECLSPEC_NOVTABLE
@@ -238,20 +236,19 @@ extern "C" {
 // __int64 as though it were intrinsic
 
 #if defined(BIT64)
-#define __int64     long
+#define __int64 long
 #else // _WIN64
-#define __int64     long long
+#define __int64 long long
 #endif // _WIN64
 
-#define __int32     int
-#define __int16     short int
-#define __int8      char        // assumes char is signed
+#define __int32 int
+#define __int16 short int
+#define __int8 char // assumes char is signed
 
 typedef void VOID, *PVOID, *LPVOID, *LPCVOID;
 
 #if !defined(PLATFORM_UNIX)
-typedef long LONG
-typedef unsigned long ULONG;
+typedef long LONG typedef unsigned long ULONG;
 typedef unsigned long DWORD
 #else
 typedef int LONG;           // NOTE: diff from windows.h, for LP64 compat
@@ -259,11 +256,11 @@ typedef unsigned int ULONG; // NOTE: diff from windows.h, for LP64 compat
 typedef unsigned int DWORD; // NOTE: diff from windows.h, for LP64 compat
 #endif
 
-#if defined (PLATFORM_UNIX)
+#if defined(PLATFORM_UNIX)
 #if defined(__cplusplus)
-typedef char16_t WCHAR;
+    typedef char16_t WCHAR;
 #else
-typedef unsigned short WCHAR;
+    typedef unsigned short WCHAR;
 #endif
 #endif
 
@@ -319,8 +316,8 @@ typedef HANDLE HINSTANCE;
 typedef LONG HRESULT;
 
 // diff from Win32
-#define MAKE_HRESULT(sev,fac,code) \
-    ((HRESULT) (((ULONG)(sev)<<31) | ((ULONG)(fac)<<16) | ((ULONG)(code))) )
+#define MAKE_HRESULT(sev, fac, code)                                           \
+  ((HRESULT)(((ULONG)(sev) << 31) | ((ULONG)(fac) << 16) | ((ULONG)(code))))
 
 #define _HRESULT_TYPEDEF_(_sc) ((HRESULT)_sc)
 
@@ -333,8 +330,7 @@ typedef LONG HRESULT;
 #define SEVERITY_ERROR 1
 
 #define SUCCEEDED(Status) ((HRESULT)(Status) >= 0)
-#define FAILED(Status) ((HRESULT)(Status)<0)
-
+#define FAILED(Status) ((HRESULT)(Status) < 0)
 
 // EH
 
@@ -344,73 +340,74 @@ typedef LONG HRESULT;
 #define EXCEPTION_MAXIMUM_PARAMETERS 15
 
 typedef struct _EXCEPTION_RECORD {
-    DWORD ExceptionCode;
-    DWORD ExceptionFlags;
-    struct _EXCEPTION_RECORD *ExceptionRecord;
-    PVOID ExceptionAddress;
-    DWORD NumberParameters;
-    ULONG_PTR ExceptionInformation[EXCEPTION_MAXIMUM_PARAMETERS];
+  DWORD ExceptionCode;
+  DWORD ExceptionFlags;
+  struct _EXCEPTION_RECORD *ExceptionRecord;
+  PVOID ExceptionAddress;
+  DWORD NumberParameters;
+  ULONG_PTR ExceptionInformation[EXCEPTION_MAXIMUM_PARAMETERS];
 } EXCEPTION_RECORD, *PEXCEPTION_RECORD;
 
 typedef struct _EXCEPTION_POINTERS {
-    PEXCEPTION_RECORD ExceptionRecord;
-    PVOID ContextRecord;
+  PEXCEPTION_RECORD ExceptionRecord;
+  PVOID ContextRecord;
 } EXCEPTION_POINTERS, *PEXCEPTION_POINTERS, *LPEXCEPTION_POINTERS;
 
-#define EXCEPTION_CONTINUE_SEARCH   0
-#define EXCEPTION_EXECUTE_HANDLER   1
+#define EXCEPTION_CONTINUE_SEARCH 0
+#define EXCEPTION_EXECUTE_HANDLER 1
 #define EXCEPTION_CONTINUE_EXECUTION -1
 
-#define GetExceptionCode (DWORD)__exception_code
-#define GetExceptionInformation (PEXCEPTION_POINTERS)__exception_info
+#define GetExceptionCode (DWORD) __exception_code
+#define GetExceptionInformation (PEXCEPTION_POINTERS) __exception_info
 
 #define METHOD_CANNOT_BE_FOLDED_DEBUG
 
-#define ANNOTATION_TRY_BEGIN                { }
-#define ANNOTATION_TRY_END                  { }
-#define ANNOTATION_FN_THROWS                { }
-#define ANNOTATION_FN_GC_NOTRIGGER          { }
-#define ANNOTATION_FN_SO_TOLERANT           { }
+#define ANNOTATION_TRY_BEGIN                                                   \
+  {}
+#define ANNOTATION_TRY_END                                                     \
+  {}
+#define ANNOTATION_FN_THROWS                                                   \
+  {}
+#define ANNOTATION_FN_GC_NOTRIGGER                                             \
+  {}
+#define ANNOTATION_FN_SO_TOLERANT                                              \
+  {}
 
-#define STATIC_CONTRACT_THROWS              ANNOTATION_FN_THROWS
-#define STATIC_CONTRACT_GC_NOTRIGGER        ANNOTATION_FN_GC_NOTRIGGER
-#define STATIC_CONTRACT_SO_TOLERANT         ANNOTATION_FN_SO_TOLERANT
+#define STATIC_CONTRACT_THROWS ANNOTATION_FN_THROWS
+#define STATIC_CONTRACT_GC_NOTRIGGER ANNOTATION_FN_GC_NOTRIGGER
+#define STATIC_CONTRACT_SO_TOLERANT ANNOTATION_FN_SO_TOLERANT
 
-namespace StaticContract
-{
-    struct ScanThrowMarkerStandard
-    {
-        __attribute__((noinline)) ScanThrowMarkerStandard()
-        {
-            METHOD_CANNOT_BE_FOLDED_DEBUG;
-            STATIC_CONTRACT_THROWS;
-            STATIC_CONTRACT_GC_NOTRIGGER;
-            STATIC_CONTRACT_SO_TOLERANT;
-        }
-    };
+namespace StaticContract {
+struct ScanThrowMarkerStandard {
+  __attribute__((noinline)) ScanThrowMarkerStandard() {
+    METHOD_CANNOT_BE_FOLDED_DEBUG;
+    STATIC_CONTRACT_THROWS;
+    STATIC_CONTRACT_GC_NOTRIGGER;
+    STATIC_CONTRACT_SO_TOLERANT;
+  }
+};
 
-    struct ScanThrowMarkerTerminal
-    {
-        __attribute__((noinline)) ScanThrowMarkerTerminal()
-        {
-            METHOD_CANNOT_BE_FOLDED_DEBUG;
-        }
-    };
+struct ScanThrowMarkerTerminal {
+  __attribute__((noinline)) ScanThrowMarkerTerminal() {
+    METHOD_CANNOT_BE_FOLDED_DEBUG;
+  }
+};
 
-    struct ScanThrowMarkerIgnore
-    {
-        __attribute__((noinline)) ScanThrowMarkerIgnore()
-        {
-            METHOD_CANNOT_BE_FOLDED_DEBUG;
-        }
-    };
+struct ScanThrowMarkerIgnore {
+  __attribute__((noinline)) ScanThrowMarkerIgnore() {
+    METHOD_CANNOT_BE_FOLDED_DEBUG;
+  }
+};
 }
 typedef StaticContract::ScanThrowMarkerStandard ScanThrowMarker;
 
 // This is used to annotate code as throwing a terminal exception, and should
 // be used immediately before the throw so that infer that it can be inferred
 // that the block in which this annotation appears throws unconditionally.
-#define SCAN_THROW_MARKER do { ScanThrowMarker __throw_marker; } while (0)
+#define SCAN_THROW_MARKER                                                      \
+  do {                                                                         \
+    ScanThrowMarker __throw_marker;                                            \
+  } while (0)
 
 #define SCAN_EHMARKER()
 #define SCAN_EHMARKER_TRY()
@@ -419,128 +416,113 @@ typedef StaticContract::ScanThrowMarkerStandard ScanThrowMarker;
 #define SCAN_EHMARKER_END_CATCH()
 
 #if defined(__cplusplus)
-extern "C"
-{
+extern "C" {
 #endif // __cplusplus
 
-    //
-    // Exception Handling ABI Level I: Base ABI
-    //
+//
+// Exception Handling ABI Level I: Base ABI
+//
 
-    typedef enum
-    {
-        _URC_NO_REASON = 0,
-        _URC_FOREIGN_EXCEPTION_CAUGHT = 1,
-        _URC_FATAL_PHASE2_ERROR = 2,
-        _URC_FATAL_PHASE1_ERROR = 3,
-        _URC_NORMAL_STOP = 4,
-        _URC_END_OF_STACK = 5,
-        _URC_HANDLER_FOUND = 6,
-        _URC_INSTALL_CONTEXT = 7,
-        _URC_CONTINUE_UNWIND = 8,
-    } _Unwind_Reason_Code;
+typedef enum {
+  _URC_NO_REASON = 0,
+  _URC_FOREIGN_EXCEPTION_CAUGHT = 1,
+  _URC_FATAL_PHASE2_ERROR = 2,
+  _URC_FATAL_PHASE1_ERROR = 3,
+  _URC_NORMAL_STOP = 4,
+  _URC_END_OF_STACK = 5,
+  _URC_HANDLER_FOUND = 6,
+  _URC_INSTALL_CONTEXT = 7,
+  _URC_CONTINUE_UNWIND = 8,
+} _Unwind_Reason_Code;
 
-    typedef enum
-    {
-        _UA_SEARCH_PHASE = 1,
-        _UA_CLEANUP_PHASE = 2,
-        _UA_HANDLER_FRAME = 4,
-        _UA_FORCE_UNWIND = 8,
-    } _Unwind_Action;
-    #define _UA_PHASE_MASK (_UA_SEARCH_PHASE|_UA_CLEANUP_PHASE)
+typedef enum {
+  _UA_SEARCH_PHASE = 1,
+  _UA_CLEANUP_PHASE = 2,
+  _UA_HANDLER_FRAME = 4,
+  _UA_FORCE_UNWIND = 8,
+} _Unwind_Action;
+#define _UA_PHASE_MASK (_UA_SEARCH_PHASE | _UA_CLEANUP_PHASE)
 
-    struct _Unwind_Context;
+struct _Unwind_Context;
 
-    void *_Unwind_GetIP(struct _Unwind_Context *context);
-    void _Unwind_SetIP(struct _Unwind_Context *context, void *new_value);
-    void *_Unwind_GetCFA(struct _Unwind_Context *context);
-    void *_Unwind_GetGR(struct _Unwind_Context *context, int index);
-    void _Unwind_SetGR(struct _Unwind_Context *context, int index,
-                       void *new_value);
+void *_Unwind_GetIP(struct _Unwind_Context *context);
+void _Unwind_SetIP(struct _Unwind_Context *context, void *new_value);
+void *_Unwind_GetCFA(struct _Unwind_Context *context);
+void *_Unwind_GetGR(struct _Unwind_Context *context, int index);
+void _Unwind_SetGR(struct _Unwind_Context *context, int index, void *new_value);
 
-    struct _Unwind_Exception;
+struct _Unwind_Exception;
 
-    typedef void (*_Unwind_Exception_Cleanup_Fn)(
-        _Unwind_Reason_Code urc,
-        struct _Unwind_Exception *exception_object);
+typedef void (*_Unwind_Exception_Cleanup_Fn)(
+    _Unwind_Reason_Code urc, struct _Unwind_Exception *exception_object);
 
-    struct _Unwind_Exception
-    {
-        ULONG64 exception_class;
-        _Unwind_Exception_Cleanup_Fn exception_cleanup;
-        UINT_PTR private_1;
-        UINT_PTR private_2;
-    } __attribute__((aligned));
+struct _Unwind_Exception {
+  ULONG64 exception_class;
+  _Unwind_Exception_Cleanup_Fn exception_cleanup;
+  UINT_PTR private_1;
+  UINT_PTR private_2;
+} __attribute__((aligned));
 
-    void _Unwind_DeleteException(struct _Unwind_Exception *exception_object);
+void _Unwind_DeleteException(struct _Unwind_Exception *exception_object);
 
-    typedef _Unwind_Reason_Code
-    (*_Unwind_Trace_Fn)(struct _Unwind_Context *context, void *pvParam);
-    _Unwind_Reason_Code _Unwind_Backtrace(_Unwind_Trace_Fn pfnTrace,
-                                          void *pvParam);
+typedef _Unwind_Reason_Code (*_Unwind_Trace_Fn)(struct _Unwind_Context *context,
+                                                void *pvParam);
+_Unwind_Reason_Code _Unwind_Backtrace(_Unwind_Trace_Fn pfnTrace, void *pvParam);
 
-    _Unwind_Reason_Code
-    _Unwind_RaiseException(struct _Unwind_Exception *exception_object);
-    __attribute__((noreturn)) void
-    _Unwind_Resume(struct _Unwind_Exception *exception_object);
+_Unwind_Reason_Code
+_Unwind_RaiseException(struct _Unwind_Exception *exception_object);
+__attribute__((noreturn)) void _Unwind_Resume(
+    struct _Unwind_Exception *exception_object);
 
-    //
-    // Exception Handling ABI Level II: C++ ABI
-    //
+//
+// Exception Handling ABI Level II: C++ ABI
+//
 
-    void *__cxa_begin_catch(void *exceptionObject) throw();
-    void __cxa_end_catch();
+void *__cxa_begin_catch(void *exceptionObject) throw();
+void __cxa_end_catch();
 
 #if defined(__cplusplus)
 };
-#endif // __cplusplus
+#endif                               // __cplusplus
 
 typedef LONG EXCEPTION_DISPOSITION;
 
 enum {
-    ExceptionContinueExecution,
-    ExceptionContinueSearch,
-    ExceptionNestedException,
-    ExceptionCollidedUnwind,
+  ExceptionContinueExecution,
+  ExceptionContinueSearch,
+  ExceptionNestedException,
+  ExceptionCollidedUnwind,
 };
 
 // A pretend exception code that we use to stand for external exceptions,
 // such as a C++ exception leaking across a P/Invoke boundary into
 // COMPlusFrameHandler.
-#define EXCEPTION_FOREIGN 0xe0455874    // 0xe0000000 | 'EXT'
+#define EXCEPTION_FOREIGN 0xe0455874 // 0xe0000000 | 'EXT'
 
 // Test whether the argument exceptionObject is an SEH exception.  If it is,
 // return the associated exception pointers.  If it is not, return NULL.
 typedef void (*PFN_PAL_BODY)(void *pvParam);
 
 typedef struct _PAL_DISPATCHER_CONTEXT {
-    _Unwind_Action actions;
-    struct _Unwind_Exception *exception_object;
-    struct _Unwind_Context *context;
+  _Unwind_Action actions;
+  struct _Unwind_Exception *exception_object;
+  struct _Unwind_Context *context;
 } PAL_DISPATCHER_CONTEXT;
 
 typedef EXCEPTION_DISPOSITION (*PFN_PAL_EXCEPTION_FILTER)(
     EXCEPTION_POINTERS *ExceptionPointers,
-    PAL_DISPATCHER_CONTEXT *DispatcherContext,
-    void *pvParam);
+    PAL_DISPATCHER_CONTEXT *DispatcherContext, void *pvParam);
 
 PALIMPORT
 PALAPI
-struct _Unwind_Exception *PAL_TryExcept(
-    PFN_PAL_BODY pfnBody,
-    PFN_PAL_EXCEPTION_FILTER pfnFilter,
-    void *pvParam,
-    BOOL *pfExecuteHandler);
+struct _Unwind_Exception *PAL_TryExcept(PFN_PAL_BODY pfnBody,
+                                        PFN_PAL_EXCEPTION_FILTER pfnFilter,
+                                        void *pvParam, BOOL *pfExecuteHandler);
 
 PALIMPORT
-VOID
-PALAPI
-RaiseException(
-           DWORD dwExceptionCode,
-           DWORD dwExceptionFlags,
-           DWORD nNumberOfArguments,
-           const ULONG_PTR *lpArguments);
-
+VOID PALAPI RaiseException(DWORD dwExceptionCode, DWORD dwExceptionFlags,
+                           DWORD nNumberOfArguments,
+                           const ULONG_PTR *lpArguments);
 
 //
 // Possible results from PAL_TryExcept:
@@ -563,150 +545,128 @@ RaiseException(
 #define PAL_DUMMY_CALL
 
 #if defined(__cplusplus)
-class PAL_CatchHolder
-{
+class PAL_CatchHolder {
 public:
-    PAL_CatchHolder(_Unwind_Exception *exceptionObject)
-    {
-        __cxa_begin_catch(exceptionObject);
-    }
+  PAL_CatchHolder(_Unwind_Exception *exceptionObject) {
+    __cxa_begin_catch(exceptionObject);
+  }
 
-    ~PAL_CatchHolder()
-    {
-        __cxa_end_catch();
-    }
+  ~PAL_CatchHolder() { __cxa_end_catch(); }
 };
 
-class PAL_ExceptionHolder
-{
+class PAL_ExceptionHolder {
 private:
-    _Unwind_Exception *m_exceptionObject;
+  _Unwind_Exception *m_exceptionObject;
+
 public:
-    PAL_ExceptionHolder(_Unwind_Exception *exceptionObject)
-    {
-        m_exceptionObject = exceptionObject;
-    }
+  PAL_ExceptionHolder(_Unwind_Exception *exceptionObject) {
+    m_exceptionObject = exceptionObject;
+  }
 
-    ~PAL_ExceptionHolder()
-    {
-        if (m_exceptionObject)
-        {
-            _Unwind_DeleteException(m_exceptionObject);
-        }
+  ~PAL_ExceptionHolder() {
+    if (m_exceptionObject) {
+      _Unwind_DeleteException(m_exceptionObject);
     }
+  }
 
-    void SuppressRelease()
-    {
-        m_exceptionObject = 0;
-    }
+  void SuppressRelease() { m_exceptionObject = 0; }
 };
 
-class PAL_NoHolder
-{
+class PAL_NoHolder {
 public:
-    void SuppressRelease() {}
+  void SuppressRelease() {}
 };
 #endif // __cplusplus
 
 #define PAL_TRY(__ParamType, __paramDef, __paramRef)                           \
-{                                                                              \
-    struct __HandlerData                                                       \
-    {                                                                          \
-        __ParamType __param;                                                   \
-        EXCEPTION_DISPOSITION __handlerDisposition;                            \
-        __HandlerData(__ParamType param) : __param(param) {}                   \
+  {                                                                            \
+    struct __HandlerData {                                                     \
+      __ParamType __param;                                                     \
+      EXCEPTION_DISPOSITION __handlerDisposition;                              \
+      __HandlerData(__ParamType param) : __param(param) {}                     \
     };                                                                         \
     __HandlerData __handlerData(__paramRef);                                   \
-    class __Body                                                               \
-    {                                                                          \
+    class __Body {                                                             \
     public:                                                                    \
-        static void run(void *__pvHandlerData)                                 \
-        {                                                                      \
-            __ParamType __paramDef =                                           \
-                ((__HandlerData *)__pvHandlerData)->__param;                   \
-            PAL_DUMMY_CALL;
+      static void run(void *__pvHandlerData) {                                 \
+        __ParamType __paramDef = ((__HandlerData *)__pvHandlerData)->__param;  \
+        PAL_DUMMY_CALL;
 
 // On Windows 32bit, we dont invoke filters on the second pass. To ensure the
 // same happens on other platforms, we check if we are in the first phase or
 // not. If we are, we invoke the filter and save the disposition in a local
-// static. 
+// static.
 //
 // However, if we are not in the first phase but in the second, and thus
 // unwinding, then we return the disposition saved from the first pass back
 // (similar to how CRT does it on x86).
 #define PAL_EXCEPT(dispositionExpression)                                      \
-        }                                                                      \
-        static EXCEPTION_DISPOSITION Handler(                                  \
-            EXCEPTION_POINTERS *ExceptionPointers,                             \
-            PAL_DISPATCHER_CONTEXT *DispatcherContext,                         \
-            void *pvHandlerData)                                               \
-        {                                                                      \
-            DEBUG_OK_TO_RETURN_BEGIN(PAL_EXCEPT)                               \
-            __HandlerData *pHandlerData = (__HandlerData *)pvHandlerData;      \
-            void *pvParam = NULL;                                              \
-            pvParam = pHandlerData->__param;                                   \
-            if (!(ExceptionPointers->ExceptionRecord->ExceptionFlags &         \
-                    EXCEPTION_UNWINDING))                                      \
-                pHandlerData->__handlerDisposition =                           \
-                    (EXCEPTION_DISPOSITION) (dispositionExpression);           \
-            return pHandlerData->__handlerDisposition;                         \
-            DEBUG_OK_TO_RETURN_END(PAL_EXCEPT)                                 \
-        }                                                                      \
-    };                                                                         \
-    BOOL __fExecuteHandler;                                                    \
-    _Unwind_Exception *__exception =                                           \
-        PAL_TryExcept(__Body::run, __Body::Handler, &__handlerData,            \
-                      &__fExecuteHandler);                                     \
-    PAL_NoHolder __exceptionHolder;                                            \
-    if (__exception && __fExecuteHandler)                                      \
-    {                                                                          \
-        PAL_CatchHolder __catchHolder(__exception);                            \
-        __exception = NULL;
+  }                                                                            \
+  static EXCEPTION_DISPOSITION Handler(                                        \
+      EXCEPTION_POINTERS *ExceptionPointers,                                   \
+      PAL_DISPATCHER_CONTEXT *DispatcherContext, void *pvHandlerData) {        \
+    DEBUG_OK_TO_RETURN_BEGIN(PAL_EXCEPT)                                       \
+    __HandlerData *pHandlerData = (__HandlerData *)pvHandlerData;              \
+    void *pvParam = NULL;                                                      \
+    pvParam = pHandlerData->__param;                                           \
+    if (!(ExceptionPointers->ExceptionRecord->ExceptionFlags &                 \
+          EXCEPTION_UNWINDING))                                                \
+      pHandlerData->__handlerDisposition =                                     \
+          (EXCEPTION_DISPOSITION)(dispositionExpression);                      \
+    return pHandlerData->__handlerDisposition;                                 \
+    DEBUG_OK_TO_RETURN_END(PAL_EXCEPT)                                         \
+  }                                                                            \
+  }                                                                            \
+  ;                                                                            \
+  BOOL __fExecuteHandler;                                                      \
+  _Unwind_Exception *__exception = PAL_TryExcept(                              \
+      __Body::run, __Body::Handler, &__handlerData, &__fExecuteHandler);       \
+  PAL_NoHolder __exceptionHolder;                                              \
+  if (__exception && __fExecuteHandler) {                                      \
+    PAL_CatchHolder __catchHolder(__exception);                                \
+    __exception = NULL;
 
 #define PAL_EXCEPT_FILTER(filter) PAL_EXCEPT(filter(ExceptionPointers, pvParam))
 
 // Executes the handler if the specified exception code matches
 // the one in the exception. Otherwise, returns EXCEPTION_CONTINUE_SEARCH.
 #define PAL_EXCEPT_IF_EXCEPTION_CODE(dwExceptionCode)                          \
-        PAL_EXCEPT(((ExceptionPointers->ExceptionRecord->ExceptionCode ==      \
-            dwExceptionCode) ?                                                 \
-                EXCEPTION_EXECUTE_HANDLER:EXCEPTION_CONTINUE_SEARCH))
+  PAL_EXCEPT(                                                                  \
+      ((ExceptionPointers->ExceptionRecord->ExceptionCode == dwExceptionCode)  \
+           ? EXCEPTION_EXECUTE_HANDLER                                         \
+           : EXCEPTION_CONTINUE_SEARCH))
 
 #define PAL_FINALLY                                                            \
-        }                                                                      \
-        static EXCEPTION_DISPOSITION Filter(                                   \
-            EXCEPTION_POINTERS *ExceptionPointers,                             \
-            PAL_DISPATCHER_CONTEXT *DispatcherContext,                         \
-            void *pvHandlerData)                                               \
-        {                                                                      \
-            DEBUG_OK_TO_RETURN_BEGIN(PAL_FINALLY)                              \
-            return EXCEPTION_CONTINUE_SEARCH;                                  \
-            DEBUG_OK_TO_RETURN_END(PAL_FINALLY)                                \
-        }                                                                      \
-    };                                                                         \
-    BOOL __fExecuteHandler;                                                    \
-    _Unwind_Exception *__exception =                                           \
-        PAL_TryExcept(__Body::run, __Body::Filter, &__handlerData,             \
-                      &__fExecuteHandler);                                     \
-    PAL_ExceptionHolder __exceptionHolder(__exception);                        \
-    {
+  }                                                                            \
+  static EXCEPTION_DISPOSITION Filter(                                         \
+      EXCEPTION_POINTERS *ExceptionPointers,                                   \
+      PAL_DISPATCHER_CONTEXT *DispatcherContext, void *pvHandlerData) {        \
+    DEBUG_OK_TO_RETURN_BEGIN(PAL_FINALLY)                                      \
+    return EXCEPTION_CONTINUE_SEARCH;                                          \
+    DEBUG_OK_TO_RETURN_END(PAL_FINALLY)                                        \
+  }                                                                            \
+  }                                                                            \
+  ;                                                                            \
+  BOOL __fExecuteHandler;                                                      \
+  _Unwind_Exception *__exception = PAL_TryExcept(                              \
+      __Body::run, __Body::Filter, &__handlerData, &__fExecuteHandler);        \
+  PAL_ExceptionHolder __exceptionHolder(__exception);                          \
+  {
 
 #define PAL_ENDTRY                                                             \
-    }                                                                          \
-    if (__exception)                                                           \
-    {                                                                          \
-        __exceptionHolder.SuppressRelease();                                   \
-        _Unwind_Resume(__exception);                                           \
-    }                                                                          \
-}
-
+  }                                                                            \
+  if (__exception) {                                                           \
+    __exceptionHolder.SuppressRelease();                                       \
+    _Unwind_Resume(__exception);                                               \
+  }                                                                            \
+  }
 
 // COM
 typedef struct _GUID {
-    ULONG   Data1;    // NOTE: diff from Win32, for LP64
-    USHORT  Data2;
-    USHORT  Data3;
-    UCHAR   Data4[ 8 ];
+  ULONG Data1; // NOTE: diff from Win32, for LP64
+  USHORT Data2;
+  USHORT Data3;
+  UCHAR Data4[8];
 } GUID;
 
 #if defined(__cplusplus)
@@ -729,17 +689,17 @@ typedef GUID CLSID;
 #define REFCLSID const CLSID *
 #endif
 
-#define MIDL_INTERFACE(x)   struct DECLSPEC_NOVTABLE
+#define MIDL_INTERFACE(x) struct DECLSPEC_NOVTABLE
 
-#define EXTERN_GUID(itf,l1,s1,s2,c1,c2,c3,c4,c5,c6,c7,c8)                      \
-    EXTERN_C const IID DECLSPEC_SELECTANY itf =                                \
-        {l1,s1,s2,{c1,c2,c3,c4,c5,c6,c7,c8}}
+#define EXTERN_GUID(itf, l1, s1, s2, c1, c2, c3, c4, c5, c6, c7, c8)           \
+  EXTERN_C const IID DECLSPEC_SELECTANY                                        \
+      itf = {l1, s1, s2, {c1, c2, c3, c4, c5, c6, c7, c8}}
 
 #define interface struct
 
 #define DECLARE_INTERFACE(iface) interface DECLSPEC_NOVTABLE iface
 #define DECLARE_INTERFACE_(iface, baseiface)                                   \
-    interface DECLSPEC_NOVTABLE iface : public baseiface
+  interface DECLSPEC_NOVTABLE iface : public baseiface
 
 typedef interface IUnknown IUnknown;
 
@@ -749,15 +709,13 @@ typedef /* [unique] */ IUnknown *LPUNKNOWN;
 EXTERN_C const IID IID_IUnknown;
 
 MIDL_INTERFACE("00000000-0000-0000-C000-000000000046")
-IUnknown
-{
-    virtual HRESULT STDMETHODCALLTYPE QueryInterface(
-        REFIID riid,
-        void **ppvObject) = 0;
+IUnknown {
+  virtual HRESULT STDMETHODCALLTYPE
+  QueryInterface(REFIID riid, void **ppvObject) = 0;
 
-    virtual ULONG STDMETHODCALLTYPE AddRef( void) = 0;
+  virtual ULONG STDMETHODCALLTYPE AddRef(void) = 0;
 
-    virtual ULONG STDMETHODCALLTYPE Release( void) = 0;
+  virtual ULONG STDMETHODCALLTYPE Release(void) = 0;
 };
 
 interface IStream;
@@ -768,16 +726,16 @@ typedef SHORT VARIANT_BOOL;
 typedef LONG SCODE;
 
 typedef union tagCY {
-    struct {
+  struct {
 #if BIGENDIAN
-        LONG    Hi;
-        ULONG   Lo;
+    LONG Hi;
+    ULONG Lo;
 #else
-        ULONG   Lo;
-        LONG    Hi;
+    ULONG Lo;
+    LONG Hi;
 #endif
-    } u;
-    LONGLONG int64;
+  } u;
+  LONGLONG int64;
 } CY;
 
 typedef WCHAR *BSTR;
@@ -785,103 +743,98 @@ typedef double DATE;
 
 typedef struct tagDEC {
 #if BIGENDIAN
-    union {
-        struct {
-            BYTE sign;
-            BYTE scale;
-        } u;
-        USHORT signscale;
+  union {
+    struct {
+      BYTE sign;
+      BYTE scale;
     } u;
-    USHORT wReserved;
+    USHORT signscale;
+  } u;
+  USHORT wReserved;
 #else
-    USHORT wReserved;
-    union {
-        struct {
-            BYTE scale;
-            BYTE sign;
-        } u;
-        USHORT signscale;
+  USHORT wReserved;
+  union {
+    struct {
+      BYTE scale;
+      BYTE sign;
     } u;
+    USHORT signscale;
+  } u;
 #endif
-    ULONG Hi32;
-    union {
-        struct {
-            ULONG Lo32;
-            ULONG Mid32;
-        } v;
-        ULONGLONG Lo64;
+  ULONG Hi32;
+  union {
+    struct {
+      ULONG Lo32;
+      ULONG Mid32;
     } v;
+    ULONGLONG Lo64;
+  } v;
 } DECIMAL;
 
 typedef unsigned short VARTYPE;
 
 typedef struct tagVARIANT VARIANT;
 
-struct tagVARIANT
-{
-    union
-    {
-        struct
-        {
-    #if BIGENDIAN
-            WORD wReserved1;
-            VARTYPE vt;
-    #else
-            VARTYPE vt;
-            WORD wReserved1;
-    #endif
-            WORD wReserved2;
-            WORD wReserved3;
-            union
-            {
-                LONGLONG llVal;
-                LONG lVal;
-                BYTE bVal;
-                SHORT iVal;
-                FLOAT fltVal;
-                DOUBLE dblVal;
-                VARIANT_BOOL boolVal;
-                SCODE scode;
-                CY cyVal;
-                DATE date;
-                BSTR bstrVal;
-                interface IUnknown *punkVal;
-                BYTE *pbVal;
-                SHORT *piVal;
-                LONG *plVal;
-                LONGLONG *pllVal;
-                FLOAT *pfltVal;
-                DOUBLE *pdblVal;
-                VARIANT_BOOL *pboolVal;
-                SCODE *pscode;
-                CY *pcyVal;
-                DATE *pdate;
-                BSTR *pbstrVal;
-                interface IUnknown **ppunkVal;
-                VARIANT *pvarVal;
-                PVOID byref;
-                CHAR cVal;
-                USHORT uiVal;
-                ULONG ulVal;
-                ULONGLONG ullVal;
-                INT intVal;
-                UINT uintVal;
-                DECIMAL *pdecVal;
-                CHAR *pcVal;
-                USHORT *puiVal;
-                ULONG *pulVal;
-                ULONGLONG *pullVal;
-                INT *pintVal;
-                UINT *puintVal;
-                struct __tagBRECORD
-                {
-                    PVOID pvRecord;
-                    interface IRecordInfo *pRecInfo;
-                } brecVal;
-            } n3;
-        } n2;
+struct tagVARIANT {
+  union {
+    struct {
+#if BIGENDIAN
+      WORD wReserved1;
+      VARTYPE vt;
+#else
+      VARTYPE vt;
+      WORD wReserved1;
+#endif
+      WORD wReserved2;
+      WORD wReserved3;
+      union {
+        LONGLONG llVal;
+        LONG lVal;
+        BYTE bVal;
+        SHORT iVal;
+        FLOAT fltVal;
+        DOUBLE dblVal;
+        VARIANT_BOOL boolVal;
+        SCODE scode;
+        CY cyVal;
+        DATE date;
+        BSTR bstrVal;
+        interface IUnknown *punkVal;
+        BYTE *pbVal;
+        SHORT *piVal;
+        LONG *plVal;
+        LONGLONG *pllVal;
+        FLOAT *pfltVal;
+        DOUBLE *pdblVal;
+        VARIANT_BOOL *pboolVal;
+        SCODE *pscode;
+        CY *pcyVal;
+        DATE *pdate;
+        BSTR *pbstrVal;
+        interface IUnknown **ppunkVal;
+        VARIANT *pvarVal;
+        PVOID byref;
+        CHAR cVal;
+        USHORT uiVal;
+        ULONG ulVal;
+        ULONGLONG ullVal;
+        INT intVal;
+        UINT uintVal;
+        DECIMAL *pdecVal;
+        CHAR *pcVal;
+        USHORT *puiVal;
+        ULONG *pulVal;
+        ULONGLONG *pullVal;
+        INT *pintVal;
+        UINT *puintVal;
+        struct __tagBRECORD {
+          PVOID pvRecord;
+          interface IRecordInfo *pRecInfo;
+        } brecVal;
+      } n3;
+    } n2;
     DECIMAL decVal;
-    } n1;
+  } n1;
 };
 
 #endif // _MSC_VER

--- a/include/Pal/Rt/ole2.h
+++ b/include/Pal/Rt/ole2.h
@@ -3,12 +3,11 @@
 // LLILC
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. 
-// See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
 //
 // Dummy ole2.h for non-Windows platforms.
 //
 //===----------------------------------------------------------------------===//
-

--- a/include/Pal/Rt/specstrings.h
+++ b/include/Pal/Rt/specstrings.h
@@ -3,8 +3,8 @@
 // LLILC
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. 
-// See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
 //

--- a/include/Pal/Rt/windef.h
+++ b/include/Pal/Rt/windef.h
@@ -3,8 +3,8 @@
 // LLILC
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. 
-// See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
 //

--- a/include/Pal/Rt/winerror.h
+++ b/include/Pal/Rt/winerror.h
@@ -3,8 +3,8 @@
 // LLILC
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. 
-// See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
 //

--- a/include/Reader/newvstate.h
+++ b/include/Reader/newvstate.h
@@ -178,15 +178,15 @@ public:
 
   union {
     uint32_t DwOffset; // #of bytes from start of method
-    long Offset;    // for backward compat with Metadata validator
+    long Offset;       // for backward compat with Metadata validator
   };
 
   union {
     mdToken Token; // for backward compat with metadata validator
     uint8_t CallConv;
     CorElementType Elem;
-    uint32_t StackSlot;        // positon in the Stack
-    uint32_t Padding2; // to match with idl generated struct size
+    uint32_t StackSlot; // positon in the Stack
+    uint32_t Padding2;  // to match with idl generated struct size
   };
 
   union {

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -193,7 +193,6 @@ struct JITFilterCommonParams {
   EXCEPTION_POINTERS ExceptionPointers;
 };
 
-
 // Forward declarations for client defined structures
 class GenIR;  // Compiler dependent IR production
 class IRNode; // Your compiler intermediate representation
@@ -601,10 +600,8 @@ struct VerificationBranchInfo {
   VerificationBranchInfo *Next;
 };
 
-ReaderBaseNS::OPCODE parseMSILOpcode(uint8_t *ILCursor,
-                                     uint8_t **OperandCursor,
-                                     uint32_t *Increment,
-                                     ReaderBase *Reader);
+ReaderBaseNS::OPCODE parseMSILOpcode(uint8_t *ILCursor, uint8_t **OperandCursor,
+                                     uint32_t *Increment, ReaderBase *Reader);
 ReaderBaseNS::OPCODE
 parseMSILOpcodeSafely(uint8_t *ILInput, uint32_t CurretOffset,
                       uint32_t ILInputSize, uint8_t **Operand,
@@ -906,7 +903,8 @@ public:
   void verifyEqual(const VerType &A, const VerType &B);
   void verifyEqualNotEquivalent(const VerType &A, const VerType &B);
   void verifyAndReportFound(int32_t Cond, const VerType &Type, HRESULT Message);
-  void verifyAndReportFound(int32_t Cond, const VerType &Type, const char *Message);
+  void verifyAndReportFound(int32_t Cond, const VerType &Type,
+                            const char *Message);
   void verifyIsNumberType(const VerType &Type);
   void verifyIsIntegerType(const VerType &Type);
   void verifyIsObjRef(const VerType &Type);
@@ -953,8 +951,7 @@ protected:
 
   // Client defined function to initialize verification state.
   void verifyNeedsVerification();
-  VerificationState *verifyInitializeBlock(FlowGraphNode *,
-                                           uint32_t ILOffset);
+  VerificationState *verifyInitializeBlock(FlowGraphNode *, uint32_t ILOffset);
   void verPropEHInitFlow(FlowGraphNode *Block);
   void verPropHandlerInitFlow(FlowGraphNode *Block);
 
@@ -1327,8 +1324,8 @@ public:
   char *getCurrentMethodName(const char **ModuleName);
   void getCurrentMethodSigData(CorInfoCallConv *Conv, CorInfoType *ReturnType,
                                CORINFO_CLASS_HANDLE *ReturnClass,
-                               int32_t *TotalILArgs, bool *IsVarArg, bool *HasThis,
-                               uint8_t *RetSig);
+                               int32_t *TotalILArgs, bool *IsVarArg,
+                               bool *HasThis, uint8_t *RetSig);
 
   // Get entry point for function (used *only* by direct calls)
   void getFunctionEntryPoint(CORINFO_METHOD_HANDLE Function,
@@ -1364,8 +1361,8 @@ public:
                              uint32_t *OffsetAfterIndirection);
   const char *getClassName(CORINFO_CLASS_HANDLE Class);
   int32_t appendClassName(char16_t **Buffer, int32_t *BufferLen,
-                      CORINFO_CLASS_HANDLE Class, bool IncludeNamespace,
-                      bool FullInst, bool IncludeAssembly);
+                          CORINFO_CLASS_HANDLE Class, bool IncludeNamespace,
+                          bool FullInst, bool IncludeAssembly);
   GCLayoutStruct *getClassGCLayout(CORINFO_CLASS_HANDLE Class);
   uint32_t getClassAttribs(CORINFO_CLASS_HANDLE Class);
   uint32_t getClassSize(CORINFO_CLASS_HANDLE Class);
@@ -1426,8 +1423,9 @@ public:
                                CORINFO_CLASS_HANDLE *RetTypeClass,
                                const char **ModuleName);
   void getMethodSigData(CorInfoCallConv *Conv, CorInfoType *ReturnType,
-                        CORINFO_CLASS_HANDLE *ReturnClass, uint32_t *TotalILArgs,
-                        bool *IsVarArg, bool *HasThis, uint8_t *RetSig);
+                        CORINFO_CLASS_HANDLE *ReturnClass,
+                        uint32_t *TotalILArgs, bool *IsVarArg, bool *HasThis,
+                        uint8_t *RetSig);
   void getMethodInfo(CORINFO_METHOD_HANDLE Handle, CORINFO_METHOD_INFO *Info);
   void methodMustBeLoadedBeforeCodeIsRun(CORINFO_METHOD_HANDLE Handle);
 
@@ -1562,8 +1560,7 @@ public:
 
   virtual FlowGraphNode *fgNodeGetNext(FlowGraphNode *FgNode) = 0;
   virtual uint32_t fgNodeGetStartMSILOffset(FlowGraphNode *Fg) = 0;
-  virtual void fgNodeSetStartMSILOffset(FlowGraphNode *Fg,
-                                        uint32_t Offset) = 0;
+  virtual void fgNodeSetStartMSILOffset(FlowGraphNode *Fg, uint32_t Offset) = 0;
   virtual uint32_t fgNodeGetEndMSILOffset(FlowGraphNode *Fg) = 0;
   virtual void fgNodeSetEndMSILOffset(FlowGraphNode *FgNode,
                                       uint32_t Offset) = 0;
@@ -1587,8 +1584,7 @@ public:
 
   virtual void leave(uint32_t TargetOffset, bool IsNonLocal,
                      bool EndsWithNonLocalGoto, IRNode **NewIR) = 0;
-  virtual IRNode *loadArg(uint32_t ArgOrdinal, bool IsJmp,
-                          IRNode **NewIR) = 0;
+  virtual IRNode *loadArg(uint32_t ArgOrdinal, bool IsJmp, IRNode **NewIR) = 0;
   virtual IRNode *loadLocal(uint32_t ArgOrdinal, IRNode **NewIR) = 0;
   virtual IRNode *loadArgAddress(uint32_t ArgOrdinal, IRNode **NewIR) = 0;
   virtual IRNode *loadLocalAddress(uint32_t LocOrdinal, IRNode **NewIR) = 0;
@@ -1795,7 +1791,7 @@ public:
   // Allocate temporary (Reader lifetime) memory
   virtual void *getTempMemory(size_t Bytes) = 0;
 
- // Allocate procedure-lifetime memory
+  // Allocate procedure-lifetime memory
   virtual void *getProcMemory(size_t Bytes) = 0;
 
   virtual EHRegion *rgnAllocateRegion() = 0;
@@ -1845,8 +1841,7 @@ public:
   virtual IRNode *fgMakeBranch(IRNode *LabelNode, IRNode *BlockNode,
                                uint32_t CurrentOffset, bool IsConditional,
                                bool IsNominal) = 0;
-  virtual IRNode *fgMakeEndFinally(IRNode *BlockNode,
-                                   uint32_t CurrentOffset,
+  virtual IRNode *fgMakeEndFinally(IRNode *BlockNode, uint32_t CurrentOffset,
                                    bool IsLexicalEnd) = 0;
 
   // turns an unconditional branch to the entry label into a fall-through
@@ -2165,25 +2160,17 @@ public:
   }
 #endif
 
-inline int8_t readInt8(uint8_t *ILCursor) {
-  IL_LOADTYPE(ILCursor, int8_t);
-}
+inline int8_t readInt8(uint8_t *ILCursor) { IL_LOADTYPE(ILCursor, int8_t); }
 
-inline uint8_t readUInt8(uint8_t *ILCursor) {
-  IL_LOADTYPE(ILCursor, uint8_t);
-}
+inline uint8_t readUInt8(uint8_t *ILCursor) { IL_LOADTYPE(ILCursor, uint8_t); }
 
-inline int16_t readInt16(uint8_t *ILCursor) {
-  IL_LOADTYPE(ILCursor, int16_t);
-}
+inline int16_t readInt16(uint8_t *ILCursor) { IL_LOADTYPE(ILCursor, int16_t); }
 
 inline uint16_t readUInt16(uint8_t *ILCursor) {
   IL_LOADTYPE(ILCursor, uint16_t);
 }
 
-inline int32_t readInt32(uint8_t *ILCursor) {
-  IL_LOADTYPE(ILCursor, int32_t);
-}
+inline int32_t readInt32(uint8_t *ILCursor) { IL_LOADTYPE(ILCursor, int32_t); }
 
 inline uint32_t readUInt32(uint8_t *ILCursor) {
   IL_LOADTYPE(ILCursor, uint32_t);

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -172,7 +172,7 @@ public:
 
   IRNode *argList(IRNode **NewIR) override;
   IRNode *instParam(IRNode **NewIR) override;
-  
+
   IRNode *secretParam(IRNode **NewIR) override {
     throw NotYetImplementedException("secretParam");
   };
@@ -828,7 +828,7 @@ private:
   ///
   /// \p Ty - Type for the new variable.
   /// \returns Instruction establishing the variable's location.
-  llvm::Instruction * createTemporary(llvm::Type * Ty);
+  llvm::Instruction *createTemporary(llvm::Type *Ty);
 
   IRNode *
   loadManagedAddress(const std::vector<llvm::Value *> &UnmanagedAddresses,

--- a/include/Reader/vtypeinfo.h
+++ b/include/Reader/vtypeinfo.h
@@ -70,31 +70,31 @@ typedef uint32_t VerErrType;
 #define PREFIX_ASSERT(x)
 #endif
 
-SELECTANY const TITypes MapTIType[CORINFO_TYPE_COUNT] =
-    {           // see the definition of enum CorInfoType in file inc/corinfo.h
-     TI_Error,  // CORINFO_TYPE_UNDEF
-     TI_Error,  // CORINFO_TYPE_VOID
-     TI_Byte,   // CORINFO_TYPE_BOOL
-     TI_Short,  // CORINFO_TYPE_CHAR
-     TI_Byte,   // CORINFO_TYPE_BYTE
-     TI_Byte,   // CORINFO_TYPE_UBYTE
-     TI_Short,  // CORINFO_TYPE_SHORT
-     TI_Short,  // CORINFO_TYPE_USHORT
-     TI_Int,    // CORINFO_TYPE_INT
-     TI_Int,    // CORINFO_TYPE_UINT
-     TI_Long,   // CORINFO_TYPE_LONG
-     TI_Long,   // CORINFO_TYPE_ULONG
-     TI_I,      // CORINFO_TYPE_NATIVEINT
-     TI_I,      // CORINFO_TYPE_NATIVEUINT
-     TI_Float,  // CORINFO_TYPE_FLOAT
-     TI_Double, // CORINFO_TYPE_DOUBLE
-     TI_Ref,    // CORINFO_TYPE_STRING
-     TI_Ptr,    // CORINFO_TYPE_PTR
-     TI_Error,  // CORINFO_TYPE_BYREF
-     TI_Struct, // CORINFO_TYPE_VALUECLASS
-     TI_Ref,    // CORINFO_TYPE_CLASS
-     TI_Struct, // CORINFO_TYPE_REFANY
-     TI_Ref,    // CORINFO_TYPE_VAR
+SELECTANY const TITypes MapTIType[CORINFO_TYPE_COUNT] = {
+    // see the definition of enum CorInfoType in file inc/corinfo.h
+    TI_Error,  // CORINFO_TYPE_UNDEF
+    TI_Error,  // CORINFO_TYPE_VOID
+    TI_Byte,   // CORINFO_TYPE_BOOL
+    TI_Short,  // CORINFO_TYPE_CHAR
+    TI_Byte,   // CORINFO_TYPE_BYTE
+    TI_Byte,   // CORINFO_TYPE_UBYTE
+    TI_Short,  // CORINFO_TYPE_SHORT
+    TI_Short,  // CORINFO_TYPE_USHORT
+    TI_Int,    // CORINFO_TYPE_INT
+    TI_Int,    // CORINFO_TYPE_UINT
+    TI_Long,   // CORINFO_TYPE_LONG
+    TI_Long,   // CORINFO_TYPE_ULONG
+    TI_I,      // CORINFO_TYPE_NATIVEINT
+    TI_I,      // CORINFO_TYPE_NATIVEUINT
+    TI_Float,  // CORINFO_TYPE_FLOAT
+    TI_Double, // CORINFO_TYPE_DOUBLE
+    TI_Ref,    // CORINFO_TYPE_STRING
+    TI_Ptr,    // CORINFO_TYPE_PTR
+    TI_Error,  // CORINFO_TYPE_BYREF
+    TI_Struct, // CORINFO_TYPE_VALUECLASS
+    TI_Ref,    // CORINFO_TYPE_CLASS
+    TI_Struct, // CORINFO_TYPE_REFANY
+    TI_Ref,    // CORINFO_TYPE_VAR
 };
 
 inline TITypes jitType2TIType(CorInfoType Type) {
@@ -253,9 +253,9 @@ public:
       uint32_t UninitObj : 1; // used
       uint32_t ByRef : 1;     // used
       uint32_t ByRefReadOnly : 1;
-      uint32_t : 3;                // unused?
-      uint32_t ThisPtr : 1;        // used
-      uint32_t : 1;                // unused?
+      uint32_t : 3;           // unused?
+      uint32_t ThisPtr : 1;   // used
+      uint32_t : 1;           // unused?
       uint32_t GenericTypeVar : 1; // used
     } Bits;
 

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -82,8 +82,7 @@ BOOL WINAPI DllMain(HANDLE Instance, DWORD Reason, LPVOID Reserved) {
 }
 #endif // LLVM_ON_WIN32
 
-extern "C"
-void __stdcall sxsJitStartup(void *CcCallbacks) {
+extern "C" void __stdcall sxsJitStartup(void *CcCallbacks) {
   // nothing to do
 }
 

--- a/lib/Reader/GenIRStubs.cpp
+++ b/lib/Reader/GenIRStubs.cpp
@@ -57,8 +57,7 @@ IRNode *irNodeGetInsertPointAfterMSILOffset(IRNode *Node, uint32_t Offset) {
   throw NotYetImplementedException("irNodeGetInsertPointAfterMSILOffset");
 }
 
-IRNode *irNodeGetInsertPointBeforeMSILOffset(IRNode *Node,
-                                             uint32_t Offset) {
+IRNode *irNodeGetInsertPointBeforeMSILOffset(IRNode *Node, uint32_t Offset) {
   throw NotYetImplementedException("irNodeGetInsertPointBeforeMSILOffset");
 }
 
@@ -284,7 +283,8 @@ void ReaderBase::verifyDup(VerificationState *Vstate, const uint8_t *CodeAddr) {
   return;
 }
 
-void ReaderBase::verifyEndFilter(VerificationState *Vstate, uint32_t MsilOffset) {
+void ReaderBase::verifyEndFilter(VerificationState *Vstate,
+                                 uint32_t MsilOffset) {
   return;
 }
 
@@ -314,8 +314,7 @@ void ReaderBase::verifyNewObj(VerificationState *Vstate,
 }
 
 void ReaderBase::verifyBoolBranch(VerificationState *Vstate,
-                                  uint32_t NextOffset,
-                                  uint32_t TargetOffset) {
+                                  uint32_t NextOffset, uint32_t TargetOffset) {
   return;
 }
 
@@ -445,8 +444,8 @@ void ReaderBase::verifyLeave(VerificationState *Vstate) { return; }
 
 void ReaderBase::verifyBranchTarget(VerificationState *Vstate,
                                     FlowGraphNode *CurrentFGNode,
-                                    EHRegion *SrcRegion,
-                                    uint32_t TargetOffset, bool IsLeave) {
+                                    EHRegion *SrcRegion, uint32_t TargetOffset,
+                                    bool IsLeave) {
   return;
 }
 
@@ -458,7 +457,8 @@ void ReaderBase::verifyFallThrough(VerificationState *Vstate,
 }
 
 bool verCheckDelegateCreation(ReaderBaseNS::OPCODE Opcode,
-                              VerificationState *Vstate, const uint8_t *CodeAddr,
+                              VerificationState *Vstate,
+                              const uint8_t *CodeAddr,
                               mdMemberRef &TargetMemberRef, VerType FtnType,
                               VerType ObjType) {
   return false;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -8292,7 +8292,8 @@ void ReaderBase::msilToIR(void) {
 
   // Set up the initial stack
   ReaderOperandStack = createStack(
-      std::min(MethodInfo->maxStack, std::min(100u, MethodInfo->ILCodeSize)), this);
+      std::min(MethodInfo->maxStack, std::min(100u, MethodInfo->ILCodeSize)), 
+      this);
   ASSERTNR(ReaderOperandStack);
   fgNodeSetOperandStack(FgHead, ReaderOperandStack);
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3,8 +3,8 @@
 // LLILC
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. 
-// See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
 //
 //===----------------------------------------------------------------------===//
 //
@@ -260,7 +260,9 @@ ReaderBaseNS::TryKind rgnGetTryType(EHRegion *Region) {
 }
 void rgnSetTryType(EHRegion *Region, ReaderBaseNS::TryKind Type) { return; }
 int rgnGetTryCanonicalExitOffset(EHRegion *TryRegion) { return 0; }
-void rgnSetTryCanonicalExitOffset(EHRegion *TryRegion, int32_t Offset) { return; }
+void rgnSetTryCanonicalExitOffset(EHRegion *TryRegion, int32_t Offset) {
+  return;
+}
 EHRegion *rgnGetExceptFilterRegion(EHRegion *Region) { return NULL; }
 void rgnSetExceptFilterRegion(EHRegion *Region, EHRegion *FilterRegion) {
   return;
@@ -340,8 +342,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   getMethodSig(MethodHandle, &Sig);
   ReturnCorType = Sig.retType;
 
-  EntryBlock =
-    BasicBlock::Create(*JitContext->LLVMContext, "entry", Function);
+  EntryBlock = BasicBlock::Create(*JitContext->LLVMContext, "entry", Function);
 
   LLVMBuilder = new IRBuilder<>(*this->JitContext->LLVMContext);
   LLVMBuilder->SetInsertPoint(EntryBlock);
@@ -353,7 +354,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   uint32_t NumArgs = Function->getFunctionType()->getFunctionNumParams();
   ASSERT(NumArgs >= JitContext->MethodInfo->args.totalILArgs());
   uint32_t NumLocals = JitContext->MethodInfo->locals.numArgs;
-  
+
   LocalVars.resize(NumLocals);
   LocalVarCorTypes.resize(NumLocals);
   Arguments.resize(NumArgs);
@@ -399,9 +400,8 @@ void GenIR::readerPostPass(bool IsImportOnly) {
       ContextAddress = Arguments[0];
       throw NotYetImplementedException("keep alive generic context: this");
     } else {
-      ASSERT(Options &
-             (CORINFO_GENERICS_CTXT_FROM_METHODDESC |
-             CORINFO_GENERICS_CTXT_FROM_METHODTABLE));
+      ASSERT(Options & (CORINFO_GENERICS_CTXT_FROM_METHODDESC |
+                        CORINFO_GENERICS_CTXT_FROM_METHODTABLE));
       ASSERT(HasTypeParameter);
       ContextAddress = Arguments[HasThis ? (HasVarargsToken ? 2 : 1) : 0];
       throw NotYetImplementedException("keep alive generic context: !this");
@@ -410,7 +410,6 @@ void GenIR::readerPostPass(bool IsImportOnly) {
 
   // Cleanup the memory we've been using.
   delete LLVMBuilder;
-
 }
 
 #pragma endregion
@@ -452,9 +451,9 @@ void GenIR::createSym(uint32_t Num, bool IsAuto, CorInfoType CorType,
                       CORINFO_CLASS_HANDLE Class, bool IsPinned,
                       ReaderSpecialSymbolType SymType) {
 
-  // Give the symbol a plausible name. 
+  // Give the symbol a plausible name.
   //
-  // The user names for args and locals are stored in the PDB, 
+  // The user names for args and locals are stored in the PDB,
   // not in the metadata, so we can't directly access it via the jit interface.
   const char *SymName = IsAuto ? "loc" : "arg";
   bool UseNumber = false;
@@ -518,13 +517,13 @@ Function *GenIR::getFunction(CORINFO_METHOD_HANDLE MethodHandle) {
   return F;
 }
 
-// Return true if this IR node is a reference to the 
+// Return true if this IR node is a reference to the
 // original this pointer passed to the method. Can
 // conservatively return false.
 bool GenIR::objIsThis(IRNode *Obj) { return false; }
 
 // Create a new temporary with the indicated type.
-Instruction *GenIR::createTemporary(Type * Ty) {
+Instruction *GenIR::createTemporary(Type *Ty) {
   // Put the alloca for this temporary into the entry block so
   // the temporary uses can appear anywhere.
   IRBuilder<>::InsertPoint IP = LLVMBuilder->saveIP();
@@ -533,9 +532,8 @@ Instruction *GenIR::createTemporary(Type * Ty) {
     // There are no local, param or temp allocas in the entry block, so set
     // the insertion point to the first point in the block.
     LLVMBuilder->SetInsertPoint(EntryBlock->getFirstInsertionPt());
-  }
-  else {
-    // There are local, param or temp allocas. TempInsertionPoint refers to 
+  } else {
+    // There are local, param or temp allocas. TempInsertionPoint refers to
     // the last of them. Set the insertion point to the next instruction since
     // the builder will insert new instructions before the insertion point.
     LLVMBuilder->SetInsertPoint(TempInsertionPoint->getNextNode());
@@ -545,7 +543,7 @@ Instruction *GenIR::createTemporary(Type * Ty) {
   // Update the end of the alloca range.
   TempInsertionPoint = AllocaInst;
   LLVMBuilder->restoreIP(IP);
-  
+
   return AllocaInst;
 }
 
@@ -724,7 +722,7 @@ void GenIR::verifyStaticAlignment(void *FieldAddress, CorInfoType CorType,
 }
 
 void ReaderBase::debugError(const char *Filename, unsigned Linenumber,
-                                  const char *S) {
+                            const char *S) {
   assert(0);
   // TODO
   // if (s) JitContext->JitInfo->doAssert(Filename, Linenumber, S);
@@ -745,7 +743,7 @@ void ReaderBase::fatal(int ErrNum) { LLILCJit::fatal(LLILCJIT_FATAL_ERROR); }
 //===----------------------------------------------------------------------===//
 
 Type *GenIR::getType(CorInfoType CorType, CORINFO_CLASS_HANDLE ClassHandle,
-                           bool GetRefClassFields) {
+                     bool GetRefClassFields) {
   LLVMContext &LLVMContext = *this->JitContext->LLVMContext;
 
   switch (CorType) {
@@ -849,7 +847,7 @@ Type *GenIR::getType(CorInfoType CorType, CORINFO_CLASS_HANDLE ClassHandle,
 // field information for ref classes. This is used to avoid
 // getting trapped in cycles in the type reference graph.
 Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
-                                bool GetRefClassFields) {
+                          bool GetRefClassFields) {
   // Check if we've already created a type for this class handle.
   Type *ResultTy = NULL;
   StructType *StructTy = NULL;
@@ -864,7 +862,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
   if (IsArray) {
     ArrayElementType = getChildType(ClassHandle, &ArrayElementHandle);
     auto MapElement = ArrayTypeMap->find(
-      std::make_tuple(ArrayElementType, ArrayElementHandle, ArrayRank));
+        std::make_tuple(ArrayElementType, ArrayElementHandle, ArrayRank));
     if (MapElement != ArrayTypeMap->end()) {
       ResultTy = MapElement->second;
     }
@@ -897,7 +895,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
       ASSERT(ResultTy->isStructTy());
       ASSERT(!cast<StructType>(ResultTy)->isOpaque());
     }
-   
+
     if (CanReturnCachedType) {
       return ResultTy;
     }
@@ -907,7 +905,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
   LLVMContext &LLVMContext = *JitContext->LLVMContext;
   const DataLayout *DataLayout = JitContext->EE->getDataLayout();
 
-  // We need to fill in or create a new type for this class. 
+  // We need to fill in or create a new type for this class.
   if (StructTy == NULL) {
     // Need to create one ... add it to the map now so it's
     // there if we make a recursive request.
@@ -955,7 +953,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
                              &UTF8Start[UTF8Size], strictConversion);
       if (Result == conversionOK) {
         ASSERT((size_t)(&WideCharBuffer[BufferLength] -
-            (char16_t *)UTF16Start) == 0);
+                        (char16_t *)UTF16Start) == 0);
         StructTy->setName((char *)ClassName);
       }
       delete[] ClassName;
@@ -989,11 +987,11 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
   bool IsObject = false;
   bool IsTypedByref = false;
   CORINFO_CLASS_HANDLE ObjectClassHandle =
-    getBuiltinClass(CorInfoClassId::CLASSID_SYSTEM_OBJECT);
+      getBuiltinClass(CorInfoClassId::CLASSID_SYSTEM_OBJECT);
   CORINFO_CLASS_HANDLE StringClassHandle =
-    getBuiltinClass(CorInfoClassId::CLASSID_STRING);
+      getBuiltinClass(CorInfoClassId::CLASSID_STRING);
   CORINFO_CLASS_HANDLE TypedByrefClassHandle =
-    getBuiltinClass(CorInfoClassId::CLASSID_TYPED_BYREF);
+      getBuiltinClass(CorInfoClassId::CLASSID_TYPED_BYREF);
 
   if (ClassHandle == ObjectClassHandle) {
     IsObject = true;
@@ -1022,18 +1020,18 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
     ASSERT(NumFields == 0);
     ASSERT(IsRefClass);
     // Vtable is an array of pointer-sized things.
-    Type *VtableSlotTy = 
-      Type::getIntNPtrTy(LLVMContext, TargetPointerSizeInBits);
-    Type *VtableTy = ArrayType::get(VtableSlotTy, 0); 
+    Type *VtableSlotTy =
+        Type::getIntNPtrTy(LLVMContext, TargetPointerSizeInBits);
+    Type *VtableTy = ArrayType::get(VtableSlotTy, 0);
     Type *VtablePtrTy = VtableTy->getPointerTo();
     Fields.push_back(VtablePtrTy);
     ByteOffset += DataLayout->getTypeSizeInBits(VtablePtrTy) / 8;
   } else {
-    // If we have a ref class, make sure the parent class 
+    // If we have a ref class, make sure the parent class
     // field information is filled in first.
     if (IsRefClass) {
       CORINFO_CLASS_HANDLE ParentClassHandle =
-        JitContext->JitInfo->getParentType(ClassHandle);
+          JitContext->JitInfo->getParentType(ClassHandle);
       // It's always ok to ask for the details of a parent type.
       Type *PointerToParentTy = getClassType(ParentClassHandle, true, true);
       // It's possible that we added the fields to this struct if a parent
@@ -1043,7 +1041,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
       }
 
       StructType *ParentTy =
-        cast<StructType>(PointerToParentTy->getPointerElementType());
+          cast<StructType>(PointerToParentTy->getPointerElementType());
 
       // Add all the parent fields into the current struct.
       for (auto FieldIterator = ParentTy->subtype_begin();
@@ -1072,7 +1070,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
       DerivedFields.push_back(std::make_pair(FieldOffset, FieldHandle));
     }
 
-    // Putting offset first in the pair lets us use the 
+    // Putting offset first in the pair lets us use the
     // default comparator here.
     std::sort(DerivedFields.begin(), DerivedFields.end());
 
@@ -1108,7 +1106,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
         (*FieldIndexMap)[FieldHandle] = Fields.size();
       }
 
-      // Add this field to the collection. 
+      // Add this field to the collection.
       //
       // If this field is a ref class reference, we don't need the full
       // details on the referred-to class, and asking for the details here
@@ -1168,8 +1166,8 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
 
       if (EndPadSize > 0) {
         // We ought to be able to assert that the pad size
-        // is not too large, but there are cases like 
-        // System.Reflection.MetadataEnumResult.<smallResult>e__FixedBuffer 
+        // is not too large, but there are cases like
+        // System.Reflection.MetadataEnumResult.<smallResult>e__FixedBuffer
         // where the runtime adds a lot more padding than one might
         // expect.
         Type *PadTy = ArrayType::get(Type::getInt8Ty(LLVMContext), EndPadSize);
@@ -1198,10 +1196,10 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
       // type.
       CORINFO_CLASS_HANDLE ArrayElementHandle = NULL;
       CorInfoType ArrayElementCorTy =
-        getChildType(ClassHandle, &ArrayElementHandle);
+          getChildType(ClassHandle, &ArrayElementHandle);
 
       if (ArrayElementCorTy == CORINFO_TYPE_CLASS) {
-        Type *ArrayElementFieldTy = 
+        Type *ArrayElementFieldTy =
             Type::getIntNPtrTy(LLVMContext, TargetPointerSizeInBits);
         Fields.push_back(ArrayElementFieldTy);
         ByteOffset += DataLayout->getTypeSizeInBits(ArrayElementFieldTy) / 8;
@@ -1230,8 +1228,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
   if (!IsRefClass) {
 
     // Verify overall size matches up.
-    const uint32_t LLVMClassSize =
-      DataLayout->getTypeSizeInBits(StructTy) / 8;
+    const uint32_t LLVMClassSize = DataLayout->getTypeSizeInBits(StructTy) / 8;
     const uint32_t EEClassSize = getClassSize(ClassHandle);
     ASSERT(EEClassSize == LLVMClassSize);
 
@@ -1239,18 +1236,18 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
     // as the GC field info from the runtime.
     GCLayoutStruct *RuntimeGCInfo = getClassGCLayout(ClassHandle);
     const StructLayout *MainStructLayout =
-      DataLayout->getStructLayout(StructTy);
+        DataLayout->getStructLayout(StructTy);
     const uint32_t PointerSize = DataLayout->getPointerSize();
 
-    // Walk through the type in pointer-sized jumps. 
+    // Walk through the type in pointer-sized jumps.
     for (uint32_t GCOffset = 0; GCOffset < EEClassSize;
          GCOffset += PointerSize) {
       const bool ExpectGCPointer =
-        (RuntimeGCInfo != NULL) &&
+          (RuntimeGCInfo != NULL) &&
           (RuntimeGCInfo->GCLayout[GCOffset / PointerSize] !=
-        CorInfoGCType::TYPE_GC_NONE);
+           CorInfoGCType::TYPE_GC_NONE);
       const uint32_t FieldIndex =
-        MainStructLayout->getElementContainingOffset(GCOffset);
+          MainStructLayout->getElementContainingOffset(GCOffset);
       Type *FieldTy = StructTy->getStructElementType(FieldIndex);
 
       // If the field is a value class we need to dive in
@@ -1265,7 +1262,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
         while (FieldTy->isStructTy()) {
           // Offset of the Inner class within the outer class
           const uint32_t InnerBaseOffset =
-            OuterStructLayout->getElementOffset(OuterIndex);
+              OuterStructLayout->getElementOffset(OuterIndex);
           // Inner class should start at or before the outer offset
           ASSERT(InnerBaseOffset <= OuterOffset);
           // Determine target offset relative to this inner class.
@@ -1273,10 +1270,10 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
           // Get the inner class layout
           StructType *InnerStructTy = cast<StructType>(FieldTy);
           const StructLayout *InnerStructLayout =
-            DataLayout->getStructLayout(InnerStructTy);
+              DataLayout->getStructLayout(InnerStructTy);
           // Find the field at that target offset.
           const uint32_t InnerIndex =
-            InnerStructLayout->getElementContainingOffset(InnerOffset);
+              InnerStructLayout->getElementContainingOffset(InnerOffset);
           // Update for next iteration.
           FieldTy = InnerStructTy->getStructElementType(InnerIndex);
           OuterStructLayout = InnerStructLayout;
@@ -1318,7 +1315,7 @@ FunctionType *GenIR::getFunctionType(CORINFO_METHOD_HANDLE Method) {
 //
 // If the signature has an implicit 'this' parameter,
 // ThisClass must be passed in as the appropriate class handle.
-FunctionType *GenIR::getFunctionType(CORINFO_SIG_INFO &Sig, 
+FunctionType *GenIR::getFunctionType(CORINFO_SIG_INFO &Sig,
                                      CORINFO_CLASS_HANDLE ThisClass) {
   CorInfoType ReturnType = Sig.retType;
   CORINFO_CLASS_HANDLE ReturnClass = Sig.retTypeClass;
@@ -1348,7 +1345,7 @@ FunctionType *GenIR::getFunctionType(CORINFO_SIG_INFO &Sig,
 
   if (IsVarArg) {
     CORINFO_CLASS_HANDLE Class =
-      getBuiltinClass(CorInfoClassId::CLASSID_ARGUMENT_HANDLE);
+        getBuiltinClass(CorInfoClassId::CLASSID_ARGUMENT_HANDLE);
     Type *VarArgCookieType = getType(CORINFO_TYPE_PTR, Class);
     Arguments.push_back(VarArgCookieType);
   }
@@ -1356,10 +1353,10 @@ FunctionType *GenIR::getFunctionType(CORINFO_SIG_INFO &Sig,
   bool HasTypeArg = Sig.hasTypeArg();
 
   if (HasTypeArg) {
-    // maybe not the right type... for now just match what we pick in 
+    // maybe not the right type... for now just match what we pick in
     // ReaderBase::buildUpParams
     CORINFO_CLASS_HANDLE Class =
-      getBuiltinClass(CorInfoClassId::CLASSID_TYPE_HANDLE);
+        getBuiltinClass(CorInfoClassId::CLASSID_TYPE_HANDLE);
     Type *TypeArgType = getType(CORINFO_TYPE_PTR, Class);
     Arguments.push_back(TypeArgType);
   }
@@ -1796,7 +1793,7 @@ IRNode *fgNodeGetEndInsertIRNode(FlowGraphNode *FgNode) {
   } else {
     return (IRNode *)&(((BasicBlock *)FgNode)->back());
   }
-  }
+}
 
 void GenIR::replaceFlowGraphNodeUses(FlowGraphNode *OldNode,
                                      FlowGraphNode *NewNode) {
@@ -1820,27 +1817,28 @@ bool GenIR::fgCall(ReaderBaseNS::OPCODE Opcode, mdToken Token,
 
 // Small helper function that gets the next IDOM. It was pulled out-of-line
 // so that it can be called in a loop in FgNodeGetIDom.
-// TODO (Issue #38): currently we conservatively return single predecessor without 
+// TODO (Issue #38): currently we conservatively return single predecessor
+// without
 // computing the immediate dominator.
 FlowGraphNode *getNextIDom(FlowGraphNode *FgNode) {
-   return (FlowGraphNode*)FgNode->getSinglePredecessor();
+  return (FlowGraphNode *)FgNode->getSinglePredecessor();
 }
 
 FlowGraphNode *GenIR::fgNodeGetIDom(FlowGraphNode *FgNode) {
-   FlowGraphNode* Idom = getNextIDom(FgNode);
+  FlowGraphNode *Idom = getNextIDom(FgNode);
 
-   //  If the dominating block is in an EH region
-   //  and the original block is not in the same region, then this
-   //  is not a true dominance relationship. Progress to the next
-   //  dominator in the chain until we reach a true dominating
-   //  block or there are no more blocks.
-   while (nullptr != Idom
-     && fgNodeGetRegion(Idom) != fgNodeGetRegion(Function)
-     && fgNodeGetRegion(Idom) != fgNodeGetRegion(FgNode)) {
-     Idom = getNextIDom(Idom);
-   }
+  //  If the dominating block is in an EH region
+  //  and the original block is not in the same region, then this
+  //  is not a true dominance relationship. Progress to the next
+  //  dominator in the chain until we reach a true dominating
+  //  block or there are no more blocks.
+  while (nullptr != Idom &&
+         fgNodeGetRegion(Idom) != fgNodeGetRegion(Function) &&
+         fgNodeGetRegion(Idom) != fgNodeGetRegion(FgNode)) {
+    Idom = getNextIDom(Idom);
+  }
 
-   return Idom;
+  return Idom;
 }
 
 FlowGraphEdgeList *fgNodeGetSuccessorList(FlowGraphNode *FgNode) {
@@ -1981,7 +1979,7 @@ IRNode *GenIR::loadLen(IRNode *Address, IRNode **NewIR) {
   Value *Length = LLVMBuilder->CreateLoad(LengthFieldAddress);
 
   // Result is an unsigned native int.
-  IRNode *Result = convertToStackType((IRNode *)Length, 
+  IRNode *Result = convertToStackType((IRNode *)Length,
                                       CorInfoType::CORINFO_TYPE_NATIVEUINT);
   return (IRNode *)Result;
 }
@@ -1997,7 +1995,7 @@ IRNode *GenIR::loadStringLen(IRNode *Address, IRNode **NewIR) {
   // Verify this type is a string.
   StringRef StringName = cast<StructType>(StringTy)->getStructName();
   ASSERT(StringName.startswith("System.String"));
-  
+
   // Length field is at field index 1. Get its address.
   Value *LengthFieldAddress = LLVMBuilder->CreateStructGEP(Address, 1);
 
@@ -2044,7 +2042,7 @@ IRNode *GenIR::loadNull(IRNode **NewIR) {
 }
 
 IRNode *GenIR::unaryOp(ReaderBaseNS::UnaryOpcode Opcode, IRNode *Arg1,
-  IRNode **NewIR) {
+                       IRNode **NewIR) {
 
   if (Opcode == ReaderBaseNS::Neg) {
     if (Arg1->getType()->isFloatingPointTy()) {
@@ -2052,7 +2050,7 @@ IRNode *GenIR::unaryOp(ReaderBaseNS::UnaryOpcode Opcode, IRNode *Arg1,
     } else {
       return (IRNode *)LLVMBuilder->CreateNeg(Arg1);
     }
-    }
+  }
 
   if (Opcode == ReaderBaseNS::Not) {
     return (IRNode *)LLVMBuilder->CreateNot(Arg1);
@@ -2116,17 +2114,17 @@ IRNode *GenIR::binaryOp(ReaderBaseNS::BinaryOpcode Opcode, IRNode *Arg1,
   // If the result is a pointer, see if we have simple
   // pointer + int op...
   if (ResultType->isPointerTy()) {
-     if (Opcode == ReaderBaseNS::Add) {
-        IRNode *PtrAdd = genPointerAdd(Arg1, Arg2);
-        if (PtrAdd != NULL) {
-           return PtrAdd;
-        }
-     } else if (Opcode == ReaderBaseNS::Sub) {
-        IRNode *PtrSub = genPointerSub(Arg1, Arg2);
-        if (PtrSub != NULL) {
-           return PtrSub;
-        }
-     }
+    if (Opcode == ReaderBaseNS::Add) {
+      IRNode *PtrAdd = genPointerAdd(Arg1, Arg2);
+      if (PtrAdd != NULL) {
+        return PtrAdd;
+      }
+    } else if (Opcode == ReaderBaseNS::Sub) {
+      IRNode *PtrSub = genPointerSub(Arg1, Arg2);
+      if (PtrSub != NULL) {
+        return PtrSub;
+      }
+    }
   }
 
   bool IsFloat = ResultType->isFloatingPointTy();
@@ -2150,12 +2148,11 @@ IRNode *GenIR::binaryOp(ReaderBaseNS::BinaryOpcode Opcode, IRNode *Arg1,
     Arg2 = convert(ResultType, Arg2, !IsUnsigned);
   }
 
-
   IRNode *Result;
   if (IsFloat && Op == Instruction::BinaryOps::FRem) {
     // FRem must be lowered to a JIT helper call to avoid undefined symbols
     // during emit.
-    //   
+    //
     // TODO: it may be possible to delay this lowering by updating the JIT
     // APIs to allow the definition of a target library (via TargeLibraryInfo).
     CorInfoHelpFunc Helper = CORINFO_HELP_UNDEF;
@@ -2178,7 +2175,7 @@ Type *GenIR::binaryOpType(Type *Type1, Type *Type2) {
   if (Type1->isPointerTy()) {
     if (Type2->isPointerTy()) {
       return Type::getIntNTy(*this->JitContext->LLVMContext,
-        TargetPointerSizeInBits);
+                             TargetPointerSizeInBits);
     }
     ASSERTNR(!Type2->isFloatingPointTy());
     return Type1;
@@ -2213,7 +2210,7 @@ Type *GenIR::binaryOpType(Type *Type1, Type *Type2) {
 // Handle simple field access via a structural GEP.
 IRNode *GenIR::simpleFieldAddress(IRNode *BaseAddress,
                                   CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                        CORINFO_FIELD_INFO *FieldInfo,
+                                  CORINFO_FIELD_INFO *FieldInfo,
                                   IRNode **NewIR) {
   // Determine field index and referent type.
   CORINFO_FIELD_HANDLE FieldHandle = ResolvedToken->hField;
@@ -2232,14 +2229,13 @@ IRNode *GenIR::simpleFieldAddress(IRNode *BaseAddress,
     // in unverifiable IL we may not have proper referent types and
     // so may see what appear to be unrelated field accesses.
     if (BaseObjStructTy->getNumElements() >= FieldIndex) {
-       const DataLayout *DataLayout = JitContext->EE->getDataLayout();
-       const StructLayout *StructLayout =
+      const DataLayout *DataLayout = JitContext->EE->getDataLayout();
+      const StructLayout *StructLayout =
           DataLayout->getStructLayout(BaseObjStructTy);
-       const uint32_t FieldOffset = 
-          StructLayout->getElementOffset(FieldIndex);
-       ASSERT(FieldOffset == FieldInfo->offset);
+      const uint32_t FieldOffset = StructLayout->getElementOffset(FieldIndex);
+      ASSERT(FieldOffset == FieldInfo->offset);
 
-       Address = LLVMBuilder->CreateStructGEP(BaseAddress, FieldIndex);
+      Address = LLVMBuilder->CreateStructGEP(BaseAddress, FieldIndex);
     }
   }
 
@@ -2251,7 +2247,7 @@ IRNode *GenIR::simpleFieldAddress(IRNode *BaseAddress,
     // via ICorJitInfo interface so we can't create a struct version of GEP.
 
     Address = binaryOp(ReaderBaseNS::Add, BaseAddress,
-      loadConstantI(FieldInfo->offset, NewIR), NewIR);
+                       loadConstantI(FieldInfo->offset, NewIR), NewIR);
   }
 
   return (IRNode *)Address;
@@ -2297,44 +2293,44 @@ IRNode *GenIR::genPointerAdd(IRNode *Arg1, IRNode *Arg2) {
 // Handle pointer - int by emitting a flattened LLVM GEP.
 IRNode *GenIR::genPointerSub(IRNode *Arg1, IRNode *Arg2) {
 
-   // Assume 1 is base and 2 is offset
-   IRNode *BasePtr = Arg1;
-   IRNode *Offset = Arg2;
+  // Assume 1 is base and 2 is offset
+  IRNode *BasePtr = Arg1;
+  IRNode *Offset = Arg2;
 
-   // Reconsider based on types.
-   bool Arg1IsPointer = Arg1->getType()->isPointerTy();
-   bool Arg2IsPointer = Arg2->getType()->isPointerTy();
-   ASSERT(Arg1IsPointer);
+  // Reconsider based on types.
+  bool Arg1IsPointer = Arg1->getType()->isPointerTy();
+  bool Arg2IsPointer = Arg2->getType()->isPointerTy();
+  ASSERT(Arg1IsPointer);
 
-   // Bail if both args are already pointer types.
-   if (Arg1IsPointer && Arg2IsPointer) {
-      return NULL;
-   }
+  // Bail if both args are already pointer types.
+  if (Arg1IsPointer && Arg2IsPointer) {
+    return NULL;
+  }
 
-   // Bail if offset is not integral.
-   Type *OffsetTy = Offset->getType();
-   if (!OffsetTy->isIntegerTy()) {
-      return NULL;
-   }
+  // Bail if offset is not integral.
+  Type *OffsetTy = Offset->getType();
+  if (!OffsetTy->isIntegerTy()) {
+    return NULL;
+  }
 
-   // Build an LLVM GEP for the resulting address.
-   // For now we "flatten" to byte offsets.
-   Type *CharPtrTy = Type::getInt8PtrTy(
+  // Build an LLVM GEP for the resulting address.
+  // For now we "flatten" to byte offsets.
+  Type *CharPtrTy = Type::getInt8PtrTy(
       *JitContext->LLVMContext, BasePtr->getType()->getPointerAddressSpace());
-   Value *BasePtrCast = LLVMBuilder->CreateBitCast(BasePtr, CharPtrTy);
-   Value *NegOffset = LLVMBuilder->CreateNeg(Offset);
-   Value *ResultPtr = LLVMBuilder->CreateGEP(BasePtrCast, NegOffset);
-   return (IRNode *)ResultPtr;
+  Value *BasePtrCast = LLVMBuilder->CreateBitCast(BasePtr, CharPtrTy);
+  Value *NegOffset = LLVMBuilder->CreateNeg(Offset);
+  Value *ResultPtr = LLVMBuilder->CreateGEP(BasePtrCast, NegOffset);
+  return (IRNode *)ResultPtr;
 }
 
 void GenIR::storeLocal(uint32_t LocalOrdinal, IRNode *Arg1,
-                             ReaderAlignType Alignment, bool IsVolatile,
-                             IRNode **NewIR) {
+                       ReaderAlignType Alignment, bool IsVolatile,
+                       IRNode **NewIR) {
   uint32_t LocalIndex = LocalOrdinal;
   Value *LocalAddress = LocalVars[LocalIndex];
   Type *LocalTy = LocalAddress->getType()->getPointerElementType();
-  IRNode *Value = 
-    convertFromStackType(Arg1, LocalVarCorTypes[LocalIndex], LocalTy);
+  IRNode *Value =
+      convertFromStackType(Arg1, LocalVarCorTypes[LocalIndex], LocalTy);
   LLVMBuilder->CreateStore(Value, LocalAddress);
 }
 
@@ -2395,7 +2391,7 @@ GenIR::loadManagedAddress(const std::vector<Value *> &UnmanagedAddresses,
 // Load the address of the field described by pResolvedToken
 // from the object Obj.
 IRNode *GenIR::loadFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                      IRNode *Obj, IRNode **NewIR) {
+                                IRNode *Obj, IRNode **NewIR) {
   bool ObjIsThis = objIsThis(Obj);
   CORINFO_FIELD_INFO FieldInfo;
 
@@ -2453,7 +2449,7 @@ IRNode *GenIR::loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Obj,
   CORINFO_FIELD_INFO FieldInfo;
   getFieldInfo(ResolvedToken, (CORINFO_ACCESS_FLAGS)AccessFlags, &FieldInfo);
 
-  // LoadStaticField and GetFieldAddress already generate 
+  // LoadStaticField and GetFieldAddress already generate
   // checkFieldAuthorization calls, so
   // only put them in the paths that terminate other ways.
 
@@ -2472,21 +2468,21 @@ IRNode *GenIR::loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Obj,
   CORINFO_CLASS_HANDLE Class = FieldInfo.structType;
   Type *FieldTy = getType(CorInfoType, Class);
 
-  // Fields typed as GC pointers are always aligned, 
+  // Fields typed as GC pointers are always aligned,
   // so ignore any smaller alignment prefix
   if (FieldTy->isPointerTy() &&
       isManagedPointerType(cast<PointerType>(FieldTy))) {
     AlignmentPrefix = Reader_AlignNatural;
   }
 
-  // If accessing the field requires a helper, then we need to 
+  // If accessing the field requires a helper, then we need to
   // call the helper routine; we can't just load the address
   // and do a load-indirect off it.
   if (FieldInfo.fieldAccessor == CORINFO_FIELD_INSTANCE_HELPER) {
     throw NotYetImplementedException("LoadField via helper");
   }
- 
-  // The operand on top of the stack may be the address of the 
+
+  // The operand on top of the stack may be the address of the
   // valuetype, or it could be an instance of the valuetype. If
   // it's an instance, we need to get its address.
   //
@@ -2512,8 +2508,8 @@ IRNode *GenIR::loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Obj,
   } else {
     LoadInst *LoadInst = LLVMBuilder->CreateLoad(Address, IsVolatile);
     uint32_t Align = (AlignmentPrefix == Reader_AlignNatural)
-      ? TargetPointerSizeInBits / 8
-      : AlignmentPrefix;
+                         ? TargetPointerSizeInBits / 8
+                         : AlignmentPrefix;
     LoadInst->setAlignment(Align);
 
     IRNode *Result = convertToStackType((IRNode *)LoadInst, CorInfoType);
@@ -2546,7 +2542,7 @@ void GenIR::storeField(CORINFO_RESOLVED_TOKEN *FieldToken, IRNode *ValueToStore,
   Type *FieldTy = getType(FieldCorType, FieldClassHandle);
   const bool IsStructTy = FieldTy->isStructTy();
 
-  // Fields typed as GC pointers are always aligned, 
+  // Fields typed as GC pointers are always aligned,
   // so ignore any smaller alignment prefix
   if ((FieldCorType == CorInfoType::CORINFO_TYPE_CLASS) ||
       (FieldCorType == CorInfoType::CORINFO_TYPE_BYREF)) {
@@ -2559,7 +2555,7 @@ void GenIR::storeField(CORINFO_RESOLVED_TOKEN *FieldToken, IRNode *ValueToStore,
   // If the EE has asked us to use a helper to store the
   // value, then do so.
   if (FieldInfo.fieldAccessor == CORINFO_FIELD_INSTANCE_HELPER) {
-    handleMemberAccess(FieldInfo.accessAllowed, FieldInfo.accessCalloutHelper, 
+    handleMemberAccess(FieldInfo.accessAllowed, FieldInfo.accessCalloutHelper,
                        NewIR);
 
     throw NotYetImplementedException("store field via helper");
@@ -2567,13 +2563,13 @@ void GenIR::storeField(CORINFO_RESOLVED_TOKEN *FieldToken, IRNode *ValueToStore,
   }
 
   // Otherwise, obtain the address of the field.
-  IRNode *Address = 
-    getFieldAddress(FieldToken, &FieldInfo, Object, false, NewIR);
+  IRNode *Address =
+      getFieldAddress(FieldToken, &FieldInfo, Object, false, NewIR);
 
   // Stores might require write barriers. If so, call the appropriate
   // helper method.
   const bool NeedsWriteBarrier =
-    JitContext->JitInfo->isWriteBarrierHelperRequired(FieldHandle);
+      JitContext->JitInfo->isWriteBarrierHelperRequired(FieldHandle);
   if (NeedsWriteBarrier) {
     rdrCallWriteBarrierHelper(Address, ValueToStore, Alignment, IsVolatile,
                               NewIR, FieldToken, !IsStructTy, false, true,
@@ -2611,7 +2607,7 @@ void GenIR::makeStore(Type *Ty, Value *Address, Value *ValueToStore,
 }
 
 IRNode *GenIR::loadStaticField(CORINFO_RESOLVED_TOKEN *FieldToken,
-                                      bool IsVolatile, IRNode **NewIR) {
+                               bool IsVolatile, IRNode **NewIR) {
   // Gather information about the field.
   CORINFO_FIELD_HANDLE FieldHandle = FieldToken->hField;
   CORINFO_FIELD_INFO FieldInfo;
@@ -2626,7 +2622,7 @@ IRNode *GenIR::loadStaticField(CORINFO_RESOLVED_TOKEN *FieldToken,
   if (FieldInfo.fieldAccessor == CORINFO_FIELD_INTRINSIC_EMPTY_STRING) {
     void *StringHandle;
     InfoAccessType Iat = JitContext->JitInfo->emptyStringLiteral(&StringHandle);
-      return stringLiteral(mdTokenNil, StringHandle, Iat, NewIR);
+    return stringLiteral(mdTokenNil, StringHandle, Iat, NewIR);
   }
 
   // Gather information about the field type.
@@ -2641,8 +2637,7 @@ IRNode *GenIR::loadStaticField(CORINFO_RESOLVED_TOKEN *FieldToken,
   Type *PtrToFieldTy = getUnmanagedPointerType(FieldTy);
   if (Address->getType()->isIntegerTy()) {
     Address = LLVMBuilder->CreateIntToPtr(Address, PtrToFieldTy);
-  }
-  else {
+  } else {
     ASSERT(Address->getType()->isPointerTy());
     Address = LLVMBuilder->CreatePointerCast(Address, PtrToFieldTy);
   }
@@ -2668,10 +2663,10 @@ void GenIR::branch(IRNode **NewIR) {
 }
 
 IRNode *GenIR::call(ReaderBaseNS::CallOpcode Opcode, mdToken Token,
-                          mdToken ConstraintTypeRef, mdToken LoadFtnToken,
-                          bool HasReadOnlyPrefix, bool HasTailCallPrefix,
-                          bool IsUnmarkedTailCall, uint32_t CurrOffset,
-                          bool *RecursiveTailCall, IRNode **NewIR) {
+                    mdToken ConstraintTypeRef, mdToken LoadFtnToken,
+                    bool HasReadOnlyPrefix, bool HasTailCallPrefix,
+                    bool IsUnmarkedTailCall, uint32_t CurrOffset,
+                    bool *RecursiveTailCall, IRNode **NewIR) {
   ReaderCallTargetData *Data =
       (ReaderCallTargetData *)_alloca(sizeof(ReaderCallTargetData));
   if (Opcode == ReaderBaseNS::NewObj) {
@@ -2766,7 +2761,7 @@ IRNode *GenIR::callHelperImpl(CorInfoHelpFunc HelperID, Type *ReturnType,
 
   bool IsVarArg = false;
   FunctionType *FunctionType =
-    FunctionType::get(ReturnType, ArgumentTypes, IsVarArg);
+      FunctionType::get(ReturnType, ArgumentTypes, IsVarArg);
 
   Value *Target = LLVMBuilder->CreateIntToPtr(
       Address, getUnmanagedPointerType(FunctionType));
@@ -2790,7 +2785,7 @@ IRNode *GenIR::getHelperCallAddress(CorInfoHelpFunc HelperId, IRNode **NewIR) {
   // the token here is really an inlined call to
   // IMetaMakeJitHelperToken(helperId)
   return handleToIRNode((mdToken)(mdtJitHelper | HelperId), Descriptor, 0,
-    IsIndirect, IsIndirect, true, false, NewIR);
+                        IsIndirect, IsIndirect, true, false, NewIR);
 }
 
 bool GenIR::canMakeDirectCall(ReaderCallTargetData *CallTargetData) {
@@ -2798,7 +2793,7 @@ bool GenIR::canMakeDirectCall(ReaderCallTargetData *CallTargetData) {
 }
 
 IRNode *GenIR::makeDirectCallTargetNode(CORINFO_METHOD_HANDLE Method,
-  void *CodeAddr) {
+                                        void *CodeAddr) {
   uint32_t NumBits = TargetPointerSizeInBits;
   bool IsSigned = false;
 
@@ -2812,8 +2807,8 @@ IRNode *GenIR::makeDirectCallTargetNode(CORINFO_METHOD_HANDLE Method,
 };
 
 IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
-  CallArgTriple *ArgArray, uint32_t NumArgs,
-  IRNode **CallNode, IRNode **NewIR) {
+                       CallArgTriple *ArgArray, uint32_t NumArgs,
+                       IRNode **CallNode, IRNode **NewIR) {
 
   IRNode *Call = NULL, *ReturnNode = NULL;
   IRNode *TargetNode = CallTargetInfo->getCallTargetNode();
@@ -2863,22 +2858,22 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
   }
 
   // We may need to fix the type on the TargetNode.
-  const bool FixFunctionType = 
-    CallTargetInfo->isCallVirt() || CallTargetInfo->isCallI();
+  const bool FixFunctionType =
+      CallTargetInfo->isCallVirt() || CallTargetInfo->isCallI();
   if (FixFunctionType) {
     CORINFO_CLASS_HANDLE ThisClass = nullptr;
     if (SigInfo->hasThis()) {
       ThisClass = ArgArray[0].ArgClass;
     }
-    Type *FunctionTy = 
-      getUnmanagedPointerType(getFunctionType(*SigInfo, ThisClass));
+    Type *FunctionTy =
+        getUnmanagedPointerType(getFunctionType(*SigInfo, ThisClass));
     if (TargetNode->getType()->isPointerTy()) {
       TargetNode =
-        (IRNode *)LLVMBuilder->CreatePointerCast(TargetNode, FunctionTy);
+          (IRNode *)LLVMBuilder->CreatePointerCast(TargetNode, FunctionTy);
     } else {
       ASSERT(TargetNode->getType()->isIntegerTy());
       TargetNode =
-        (IRNode *)LLVMBuilder->CreateIntToPtr(TargetNode, FunctionTy);
+          (IRNode *)LLVMBuilder->CreateIntToPtr(TargetNode, FunctionTy);
     }
   } else {
     // We should have a usable type already.
@@ -2927,7 +2922,7 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
   }
 }
 
-// Canonicalizes a newobj call. 
+// Canonicalizes a newobj call.
 // Returns true if the call is done being processed.
 // Outparam is the value to be pushed on the stack (this pointer of new object).
 bool GenIR::canonNewObjCall(IRNode *CallNode,
@@ -2960,11 +2955,11 @@ bool GenIR::canonNewObjCall(IRNode *CallNode,
   } else if (IsVarObjSize) {
     // We are allocating an object whose size depends on constructor args
     // (e.g., string). In this case the call to the constructor will allocate
-    // the object. 
+    // the object.
 
     // Leave the 'this' argument to the constructor call as null.
     ASSERTNR(CallInstruction->getArgOperand(0)->getValueID() ==
-      Value::ConstantPointerNullVal);
+             Value::ConstantPointerNullVal);
 
     // Change the type of the called function and
     // the type of the CallInstruction.
@@ -2973,7 +2968,7 @@ bool GenIR::canonNewObjCall(IRNode *CallNode,
     PointerType *CalledValueType =
         dyn_cast<PointerType>(CalledValue->getType());
     FunctionType *FuncType =
-      dyn_cast<FunctionType>(CalledValueType->getElementType());
+        dyn_cast<FunctionType>(CalledValueType->getElementType());
 
     // Construct the new function type.
     std::vector<Type *> Arguments;
@@ -2983,7 +2978,7 @@ bool GenIR::canonNewObjCall(IRNode *CallNode,
     }
 
     FunctionType *NewFunctionType = FunctionType::get(
-      FuncType->getParamType(0), Arguments, FuncType->isVarArg());
+        FuncType->getParamType(0), Arguments, FuncType->isVarArg());
 
     // Create a call target with the right type.
     Value *NewCalledValue = LLVMBuilder->CreatePointerCast(
@@ -3032,7 +3027,7 @@ bool GenIR::canonNewObjCall(IRNode *CallNode,
     CorInfoHelpFunc HelperId = getNewHelper(CallTargetData->getResolvedToken());
     Value *Dest = CallInstruction->getArgOperand(0);
     Value *ThisPointer = callHelper(HelperId, (IRNode *)Dest, NewIR,
-      CallTargetData->getClassHandleNode(NewIR));
+                                    CallTargetData->getClassHandleNode(NewIR));
     CallInstruction->setArgOperand(0, ThisPointer);
     LLVMBuilder->SetInsertPoint(CurrentBlock, SavedInsertPoint);
     *OutResult = (IRNode *)ThisPointer;
@@ -3048,9 +3043,9 @@ void GenIR::canonNewArrayCall(IRNode *Call,
   Value *CalledValue = CallInstruction->getCalledValue();
   PointerType *CalledValueType = dyn_cast<PointerType>(CalledValue->getType());
   FunctionType *FuncType =
-    dyn_cast<FunctionType>(CalledValueType->getElementType());
+      dyn_cast<FunctionType>(CalledValueType->getElementType());
 
-  // To construct the array we need to call a helper passing it the class handle 
+  // To construct the array we need to call a helper passing it the class handle
   // for the constructor method, the number of arguments to the constructor and
   // the arguments to the constructor.
 
@@ -3070,7 +3065,7 @@ void GenIR::canonNewArrayCall(IRNode *Call,
   bool IsSigned = true;
   Value *NumArgs = ConstantInt::get(
       *JitContext->LLVMContext,
-    APInt(NumBits, CallTargetData->getSigInfo()->numArgs, IsSigned));
+      APInt(NumBits, CallTargetData->getSigInfo()->numArgs, IsSigned));
   ASSERTNR(NumArgs);
 
   NewTypeArguments.push_back(NumArgs->getType());
@@ -3109,14 +3104,14 @@ bool GenIR::callIsCorVarArgs(IRNode *CallNode) {
 }
 
 IRNode *GenIR::conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1,
-  IRNode **NewIR) {
+                    IRNode **NewIR) {
 
   struct ConvertInfo {
     CorInfoType CorType;
     bool CheckForOverflow;
     bool SourceIsUnsigned;
   };
- 
+
   static const ConvertInfo Map[ReaderBaseNS::LastConvOpcode] = {
       {CorInfoType::CORINFO_TYPE_BYTE, false, false},       // CONV_I1
       {CorInfoType::CORINFO_TYPE_SHORT, false, false},      // CONV_I2
@@ -3173,10 +3168,10 @@ IRNode *GenIR::conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1,
     Conversion = LLVMBuilder->CreatePtrToInt(Arg1, TargetTy);
   } else if (SourceTy->isIntegerTy() && TargetTy->isFloatingPointTy()) {
     Conversion = SourceIsSigned ? LLVMBuilder->CreateSIToFP(Arg1, TargetTy)
-      : LLVMBuilder->CreateUIToFP(Arg1, TargetTy);
+                                : LLVMBuilder->CreateUIToFP(Arg1, TargetTy);
   } else if (SourceTy->isFloatingPointTy() && TargetTy->isIntegerTy()) {
     Conversion = DestIsSigned ? LLVMBuilder->CreateFPToSI(Arg1, TargetTy)
-      : LLVMBuilder->CreateFPToUI(Arg1, TargetTy);
+                              : LLVMBuilder->CreateFPToUI(Arg1, TargetTy);
   } else if (SourceTy->isFloatingPointTy() && TargetTy->isFloatingPointTy()) {
     Conversion = LLVMBuilder->CreateFPCast(Arg1, TargetTy);
   } else {
@@ -3221,7 +3216,7 @@ IRNode *GenIR::makeCallReturnNode(CORINFO_SIG_INFO *Sig,
 // The debug messages are only wanted when checking the general case
 // and not for special recursive checks.
 bool GenIR::commonTailCallChecks(CORINFO_METHOD_HANDLE DeclaredMethod,
-                            CORINFO_METHOD_HANDLE ExactMethod,
+                                 CORINFO_METHOD_HANDLE ExactMethod,
                                  bool IsUnmarkedTailCall, bool SuppressMsgs) {
   // Note that localloc works with tail call provided that we don't perform
   // recursive tail call optimization, so there is a special check for
@@ -3261,7 +3256,7 @@ bool GenIR::commonTailCallChecks(CORINFO_METHOD_HANDLE DeclaredMethod,
   ASSERTNR(Reason != NULL);
   if (!SuppressMsgs) {
     fprintf(stderr, "ALL: %splicit tail call request not honored due to %s\n",
-      IsUnmarkedTailCall ? "im" : "ex", Reason);
+            IsUnmarkedTailCall ? "im" : "ex", Reason);
   }
   return false;
 }
@@ -3296,16 +3291,16 @@ bool GenIR::fgOptRecurse(ReaderCallTargetData *Data) {
 
   uint32_t MethodCompFlags = getCurrentMethodAttribs();
   if ((Method != getCurrentMethodHandle())
-          // Not yet implemented (but can do a regular tail call)
+      // Not yet implemented (but can do a regular tail call)
       ||
       (MethodCompFlags & CORINFO_FLG_SHAREDINST)
 #if 0
     || (SS_ATTRIB(CI_Entry(ciPtr)) & AA_VARARGS)
-#endif 
+#endif
       ||
       !Data->recordCommonTailCallChecks(commonTailCallChecks(
           Method, Method, Data->isUnmarkedTailCall(), false))
-           // treat as inlining since we're removing the call
+      // treat as inlining since we're removing the call
       ||
       (canInline(Method, Method, NULL) != INLINE_PASS)) {
     // we might want a DBFLAG msg here, but since this routine may be
@@ -3335,7 +3330,7 @@ bool GenIR::fgOptRecurse(mdToken Token) {
   PAL_TRY(Param *, PParam, &Params) {
     CORINFO_RESOLVED_TOKEN ResolvedToken;
     PParam->This->resolveToken(PParam->Token, CORINFO_TOKENKIND_Method,
-      &ResolvedToken);
+                               &ResolvedToken);
     PParam->Method = ResolvedToken.hMethod;
   }
   PAL_EXCEPT_FILTER(runtimeFilter) {
@@ -3345,19 +3340,19 @@ bool GenIR::fgOptRecurse(mdToken Token) {
   PAL_ENDTRY
 
   if (!Params.Method) {
-      return false;
-    }
+    return false;
+  }
 
   uint32_t MethodCompFlags = getCurrentMethodAttribs();
   if ((Params.Method != getCurrentMethodHandle())
-          // Not yet implemented (but can do a regular tail call)
+      // Not yet implemented (but can do a regular tail call)
       ||
       (MethodCompFlags & CORINFO_FLG_SHAREDINST)
 #if 0
     || (SS_ATTRIB(CI_Entry(ciPtr)) & AA_VARARGS)
 #endif
       || (!commonTailCallChecks(Params.Method, Params.Method, false, true))
-             // treat as inlining since we're removing the call
+      // treat as inlining since we're removing the call
       ||
       (canInline(Params.Method, Params.Method, NULL) != INLINE_PASS)) {
     // we might want a DBFLAG msg here, but since this routine may be
@@ -3424,7 +3419,7 @@ void GenIR::throwOpcode(IRNode *Arg1, IRNode **NewIR) {
 }
 
 void GenIR::leave(uint32_t TargetOffset, bool IsNonLocal,
-  bool EndsWithNonLocalGoto, IRNode **NewIR) {
+                  bool EndsWithNonLocalGoto, IRNode **NewIR) {
   // TODO: handle exiting through nested finallies
   // currently FG-building phase 1 generates an appropriate
   // branch instruction for trivial leaves and rejects others
@@ -3457,14 +3452,14 @@ IRNode *GenIR::stringLiteral(mdToken Token, void *StringHandle,
         Token, StringHandle, 0, (Iat == IAT_PPVALUE), true, true, false, NewIR);
     // Cast it to the right address type.
     CORINFO_CLASS_HANDLE StringClassHandle =
-      getBuiltinClass(CorInfoClassId::CLASSID_STRING);
+        getBuiltinClass(CorInfoClassId::CLASSID_STRING);
     Type *StringRefTy = getType(CORINFO_TYPE_CLASS, StringClassHandle);
     Type *AddressTy = getUnmanagedPointerType(StringRefTy);
-    IRNode *TypedAddress = 
+    IRNode *TypedAddress =
         (IRNode *)LLVMBuilder->CreateIntToPtr(RawAddress, AddressTy);
     // Fetch the string reference.
     StringPtrNode = loadIndir(ReaderBaseNS::LdindRef, TypedAddress,
-                                    Reader_AlignNatural, false, false, NewIR);
+                              Reader_AlignNatural, false, false, NewIR);
     break;
   }
   default:
@@ -3500,9 +3495,7 @@ IRNode *GenIR::handleToIRNode(mdToken Token, void *EmbHandle, void *RealHandle,
 
 // TODO: currently PtrType telling base or interior pointer is ignored.
 // So for now, deliberately we keep this API to retain the call site.
-IRNode *GenIR::makePtrNode(ReaderPtrType PtrType) {
-   return loadNull(nullptr);
-}
+IRNode *GenIR::makePtrNode(ReaderPtrType PtrType) { return loadNull(nullptr); }
 
 // Load a pointer-sized value from the indicated address.
 // Used when navigating through runtime data structures.
@@ -3519,8 +3512,8 @@ IRNode *GenIR::derefAddress(IRNode *Address, bool DstIsGCPtr, bool IsConst,
 
   // We don't know the true referent type so just use a pointer sized
   // integer for the result.
-  Type *ReferentTy = Type::getIntNTy(*JitContext->LLVMContext,
-                                     TargetPointerSizeInBits);
+  Type *ReferentTy =
+      Type::getIntNTy(*JitContext->LLVMContext, TargetPointerSizeInBits);
 
   // Address is a pointer, but since it may come from dereferencing into
   // runtime data structures with unknown field types, we may need a cast here
@@ -3580,20 +3573,20 @@ IRNode *GenIR::loadPrimitiveType(IRNode *Addr, CorInfoType CorInfoType,
     ASSERT(isManagedPointerType(ReferentPtrTy));
     ASSERT(ReferentTy->getPointerElementType()->isStructTy());
     // GC pointers are always naturally aligned
-    Alignment = Reader_AlignNatural; 
+    Alignment = Reader_AlignNatural;
   } else {
     // For the true primitve case we may need to cast the address.
     Type *ExpectedTy = this->getType(CorInfoType, NULL);
     if (ReferentTy != ExpectedTy) {
       Type *PtrToExpectedTy = getUnmanagedPointerType(ExpectedTy);
-      TypedAddr = 
+      TypedAddr =
           (IRNode *)LLVMBuilder->CreatePointerCast(Addr, PtrToExpectedTy);
     }
   }
 
   uint32_t Align = (Alignment == Reader_AlignNatural)
-    ? TargetPointerSizeInBits / 8
-    : Alignment;
+                       ? TargetPointerSizeInBits / 8
+                       : Alignment;
   LoadInst *LoadInst = LLVMBuilder->CreateLoad(TypedAddr, IsVolatile);
   LoadInst->setAlignment(Align);
 
@@ -3659,7 +3652,7 @@ IRNode *GenIR::cmp(ReaderBaseNS::CmpOpcode Opcode, IRNode *Arg1, IRNode *Arg2,
       Arg2 = (IRNode *)LLVMBuilder->CreateIntCast(Arg2, Ty1, IsSigned);
     }
   } else if (Ty1 != Ty2) {
-  // Make types agree without perturbing bit patterns.
+    // Make types agree without perturbing bit patterns.
     // Must be ptr-ptr or int-ptr case.
     ASSERT(IsPointer1 || IsPointer2);
 
@@ -3672,7 +3665,7 @@ IRNode *GenIR::cmp(ReaderBaseNS::CmpOpcode Opcode, IRNode *Arg1, IRNode *Arg2,
       } else {
         // Cast ptr Arg1 to match int Arg2
         Arg1 = (IRNode *)LLVMBuilder->CreatePointerCast(Arg1, Ty2);
-    }
+      }
     } else {
       // Cast ptr Arg2 to match int Arg1
       Arg2 = (IRNode *)LLVMBuilder->CreatePointerCast(Arg2, Ty1);
@@ -3688,14 +3681,14 @@ IRNode *GenIR::cmp(ReaderBaseNS::CmpOpcode Opcode, IRNode *Arg1, IRNode *Arg2,
       CmpInst::Predicate::ICMP_UGT, // CGT_UN,
       CmpInst::Predicate::ICMP_SLT, // CLT,
       CmpInst::Predicate::ICMP_ULT  // CLT_UN,
-    };
+  };
 
   static const CmpInst::Predicate FloatCmpMap[ReaderBaseNS::LastCmpOpcode] = {
-    CmpInst::Predicate::FCMP_OEQ, // CEQ,
-    CmpInst::Predicate::FCMP_OGT, // CGT,
-    CmpInst::Predicate::FCMP_UGT, // CGT_UN,
-    CmpInst::Predicate::FCMP_OLT, // CLT,
-    CmpInst::Predicate::FCMP_ULT  // CLT_UN,
+      CmpInst::Predicate::FCMP_OEQ, // CEQ,
+      CmpInst::Predicate::FCMP_OGT, // CGT,
+      CmpInst::Predicate::FCMP_UGT, // CGT_UN,
+      CmpInst::Predicate::FCMP_OLT, // CLT,
+      CmpInst::Predicate::FCMP_ULT  // CLT_UN,
   };
 
   Value *Cmp;
@@ -3715,11 +3708,11 @@ void GenIR::boolBranch(ReaderBaseNS::BoolBranchOpcode Opcode, IRNode *Arg1,
                        IRNode **NewIR) {
   static const CmpInst::Predicate
       BranchMap[ReaderBaseNS::LastBoolBranchOpcode] = {
-    CmpInst::Predicate::ICMP_EQ, // BR_FALSE = 0,
-    CmpInst::Predicate::ICMP_EQ, // BR_FALSE_S,
-    CmpInst::Predicate::ICMP_NE, // BR_TRUE,
-    CmpInst::Predicate::ICMP_NE  // BR_TRUE_S,
-  };
+          CmpInst::Predicate::ICMP_EQ, // BR_FALSE = 0,
+          CmpInst::Predicate::ICMP_EQ, // BR_FALSE_S,
+          CmpInst::Predicate::ICMP_NE, // BR_TRUE,
+          CmpInst::Predicate::ICMP_NE  // BR_TRUE_S,
+      };
 
   CmpInst::Predicate Predicate = BranchMap[Opcode];
   Constant *ZeroConst = Constant::getNullValue(Arg1->getType());
@@ -3773,7 +3766,7 @@ void GenIR::condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
       } else {
         // Cast ptr Arg1 to match int Arg2
         Arg1 = (IRNode *)LLVMBuilder->CreatePointerCast(Arg1, Ty2);
-    }
+      }
     } else {
       // Cast ptr Arg2 to match int Arg1
       Arg2 = (IRNode *)LLVMBuilder->CreatePointerCast(Arg2, Ty1);
@@ -3783,53 +3776,53 @@ void GenIR::condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
   // Types should now match up.
   ASSERT(Arg1->getType() == Arg2->getType());
 
-  static const CmpInst::Predicate 
+  static const CmpInst::Predicate
       IntBranchMap[ReaderBaseNS::LastCondBranchOpcode] = {
-      CmpInst::Predicate::ICMP_EQ,  // BEQ,
-      CmpInst::Predicate::ICMP_EQ,  // BEQ_S,
-      CmpInst::Predicate::ICMP_SGE, // BGE,
-      CmpInst::Predicate::ICMP_SGE, // BGE_S,
-      CmpInst::Predicate::ICMP_UGE, // BGE_UN,
-      CmpInst::Predicate::ICMP_UGE, // BGE_UN_S,
-      CmpInst::Predicate::ICMP_SGT, // BGT,
-      CmpInst::Predicate::ICMP_SGT, // BGT_S,
-      CmpInst::Predicate::ICMP_UGT, // BGT_UN,
-      CmpInst::Predicate::ICMP_UGT, // BGT_UN_S,
-      CmpInst::Predicate::ICMP_SLE, // BLE,
-      CmpInst::Predicate::ICMP_SLE, // BLE_S,
-      CmpInst::Predicate::ICMP_ULE, // BLE_UN,
-      CmpInst::Predicate::ICMP_ULE, // BLE_UN_S,
-      CmpInst::Predicate::ICMP_SLT, // BLT,
-      CmpInst::Predicate::ICMP_SLT, // BLT_S,
-      CmpInst::Predicate::ICMP_ULT, // BLT_UN,
-      CmpInst::Predicate::ICMP_ULT, // BLT_UN_S,
-      CmpInst::Predicate::ICMP_NE,  // BNE_UN,
-      CmpInst::Predicate::ICMP_NE   // BNE_UN_S,
-  };
+          CmpInst::Predicate::ICMP_EQ,  // BEQ,
+          CmpInst::Predicate::ICMP_EQ,  // BEQ_S,
+          CmpInst::Predicate::ICMP_SGE, // BGE,
+          CmpInst::Predicate::ICMP_SGE, // BGE_S,
+          CmpInst::Predicate::ICMP_UGE, // BGE_UN,
+          CmpInst::Predicate::ICMP_UGE, // BGE_UN_S,
+          CmpInst::Predicate::ICMP_SGT, // BGT,
+          CmpInst::Predicate::ICMP_SGT, // BGT_S,
+          CmpInst::Predicate::ICMP_UGT, // BGT_UN,
+          CmpInst::Predicate::ICMP_UGT, // BGT_UN_S,
+          CmpInst::Predicate::ICMP_SLE, // BLE,
+          CmpInst::Predicate::ICMP_SLE, // BLE_S,
+          CmpInst::Predicate::ICMP_ULE, // BLE_UN,
+          CmpInst::Predicate::ICMP_ULE, // BLE_UN_S,
+          CmpInst::Predicate::ICMP_SLT, // BLT,
+          CmpInst::Predicate::ICMP_SLT, // BLT_S,
+          CmpInst::Predicate::ICMP_ULT, // BLT_UN,
+          CmpInst::Predicate::ICMP_ULT, // BLT_UN_S,
+          CmpInst::Predicate::ICMP_NE,  // BNE_UN,
+          CmpInst::Predicate::ICMP_NE   // BNE_UN_S,
+      };
 
   static const CmpInst::Predicate
       FloatBranchMap[ReaderBaseNS::LastCondBranchOpcode] = {
-      CmpInst::Predicate::FCMP_OEQ, // BEQ,
-      CmpInst::Predicate::FCMP_OEQ, // BEQ_S,
-      CmpInst::Predicate::FCMP_OGE, // BGE,
-      CmpInst::Predicate::FCMP_OGE, // BGE_S,
-      CmpInst::Predicate::FCMP_UGE, // BGE_UN,
-      CmpInst::Predicate::FCMP_UGE, // BGE_UN_S,
-      CmpInst::Predicate::FCMP_OGT, // BGT,
-      CmpInst::Predicate::FCMP_OGT, // BGT_S,
-      CmpInst::Predicate::FCMP_UGT, // BGT_UN,
-      CmpInst::Predicate::FCMP_UGT, // BGT_UN_S,
-      CmpInst::Predicate::FCMP_OLE, // BLE,
-      CmpInst::Predicate::FCMP_OLE, // BLE_S,
-      CmpInst::Predicate::FCMP_ULE, // BLE_UN,
-      CmpInst::Predicate::FCMP_ULE, // BLE_UN_S,
-      CmpInst::Predicate::FCMP_OLT, // BLT,
-      CmpInst::Predicate::FCMP_OLT, // BLT_S,
-      CmpInst::Predicate::FCMP_ULT, // BLT_UN,
-      CmpInst::Predicate::FCMP_ULT, // BLT_UN_S,
-      CmpInst::Predicate::FCMP_UNE, // BNE_UN,
-      CmpInst::Predicate::FCMP_UNE  // BNE_UN_S,
-  };
+          CmpInst::Predicate::FCMP_OEQ, // BEQ,
+          CmpInst::Predicate::FCMP_OEQ, // BEQ_S,
+          CmpInst::Predicate::FCMP_OGE, // BGE,
+          CmpInst::Predicate::FCMP_OGE, // BGE_S,
+          CmpInst::Predicate::FCMP_UGE, // BGE_UN,
+          CmpInst::Predicate::FCMP_UGE, // BGE_UN_S,
+          CmpInst::Predicate::FCMP_OGT, // BGT,
+          CmpInst::Predicate::FCMP_OGT, // BGT_S,
+          CmpInst::Predicate::FCMP_UGT, // BGT_UN,
+          CmpInst::Predicate::FCMP_UGT, // BGT_UN_S,
+          CmpInst::Predicate::FCMP_OLE, // BLE,
+          CmpInst::Predicate::FCMP_OLE, // BLE_S,
+          CmpInst::Predicate::FCMP_ULE, // BLE_UN,
+          CmpInst::Predicate::FCMP_ULE, // BLE_UN_S,
+          CmpInst::Predicate::FCMP_OLT, // BLT,
+          CmpInst::Predicate::FCMP_OLT, // BLT_S,
+          CmpInst::Predicate::FCMP_ULT, // BLT_UN,
+          CmpInst::Predicate::FCMP_ULT, // BLT_UN_S,
+          CmpInst::Predicate::FCMP_UNE, // BNE_UN,
+          CmpInst::Predicate::FCMP_UNE  // BNE_UN_S,
+      };
 
   Value *Condition =
       IsFloat1 ? LLVMBuilder->CreateFCmp(FloatBranchMap[Opcode], Arg1, Arg2)
@@ -3844,7 +3837,7 @@ void GenIR::condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
 }
 
 IRNode *GenIR::getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-  IRNode **NewIR) {
+                                     IRNode **NewIR) {
   CORINFO_FIELD_INFO FieldInfo;
   getFieldInfo(ResolvedToken, CORINFO_ACCESS_ADDRESS, &FieldInfo);
   return rdrGetStaticFieldAddress(ResolvedToken, &FieldInfo, NewIR);
@@ -3861,10 +3854,10 @@ IRNode *GenIR::shift(ReaderBaseNS::ShiftOpcode Opcode, IRNode *ShiftAmount,
   // shift amounts have undefined behavior we can unilaterally treat the
   // amount as unsigned here.
   if (OperandType != AmountType) {
-    ShiftAmount = 
-      (IRNode *)LLVMBuilder->CreateIntCast(ShiftAmount, OperandType, false);
+    ShiftAmount =
+        (IRNode *)LLVMBuilder->CreateIntCast(ShiftAmount, OperandType, false);
   }
-  
+
   // MSIL ReaderBaseNS::SHL lowered to LLVM Instruction::BinaryOps::Shl
   if (Opcode == ReaderBaseNS::Shl) {
     return (IRNode *)LLVMBuilder->CreateShl(ShiftOperand, ShiftAmount);
@@ -3879,7 +3872,7 @@ IRNode *GenIR::shift(ReaderBaseNS::ShiftOpcode Opcode, IRNode *ShiftAmount,
   return (IRNode *)LLVMBuilder->CreateLShr(ShiftOperand, ShiftAmount);
 }
 
-/// Generate IR for MSIL Sizeof instruction. 
+/// Generate IR for MSIL Sizeof instruction.
 IRNode *GenIR::sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                             IRNode **NewIR) {
   uint32_t ClassSize = getClassSize(ResolvedToken->hClass);
@@ -3892,8 +3885,8 @@ IRNode *GenIR::sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
   return Result;
 }
 
-IRNode *GenIR::newObj(mdToken Token, mdToken LoadFtnToken,
-                      uint32_t CurrOffset, IRNode **NewIR) {
+IRNode *GenIR::newObj(mdToken Token, mdToken LoadFtnToken, uint32_t CurrOffset,
+                      IRNode **NewIR) {
   // Generate the constructor call
   // rdrCall and GenCall process newobj
   //  so there's nothing else to do.
@@ -3903,7 +3896,7 @@ IRNode *GenIR::newObj(mdToken Token, mdToken LoadFtnToken,
   bool IsUnmarkedTailCall = false;
   IRNode *Result = call(ReaderBaseNS::NewObj, Token, mdTokenNil, LoadFtnToken,
                         ReadOnlyPrefix, TailCallPrefix, IsUnmarkedTailCall,
-                               CurrOffset, &IsRecursive, NewIR);
+                        CurrOffset, &IsRecursive, NewIR);
   ASSERTNR(!IsRecursive); // No tail recursive new-obj calls
   return Result;
 }
@@ -3917,8 +3910,8 @@ IRNode *GenIR::newArr(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1,
   // This needs to be of type native int.
   Type *NumOfElementsType =
       Type::getIntNTy(*this->JitContext->LLVMContext, TargetPointerSizeInBits);
-  IRNode *NumOfElements = 
-    convertToStackType(Arg1, CorInfoType::CORINFO_TYPE_NATIVEINT);
+  IRNode *NumOfElements =
+      convertToStackType(Arg1, CorInfoType::CORINFO_TYPE_NATIVEINT);
 
   // Or token with CORINFO_ANNOT_ARRAY so that we get back an array-type handle
   bool EmbedParent = false;
@@ -3955,9 +3948,9 @@ IRNode *GenIR::castOp(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *ObjRefNode,
       // enable cast class optimization.
       HelperId = CORINFO_HELP_CHKCASTCLASS_SPECIAL;
 
-      //
-      // FALL-THROUGH
-      //
+    //
+    // FALL-THROUGH
+    //
 
     case CORINFO_HELP_ISINSTANCEOFCLASS: {
       uint32_t Flags = getClassAttribs((CORINFO_CLASS_HANDLE)HandleType);
@@ -4120,7 +4113,7 @@ void TypeInfo::dump() const {
   if (TiType == TI_Ref || TiType == TI_Struct) {
     dbgs() << "< " << toStaticString() << " m:" << Method
            << " isbyref:" << isByRef() << " isreadonly:" << isReadonlyByRef()
-      << " isthis:" << isThisPtr() 
+           << " isthis:" << isThisPtr()
            << " isvar:" << ((Flags & TI_FLAG_GENERIC_TYPE_VAR) != 0) << " >";
   } else {
     dbgs() << "< " << toStaticString() << " >";
@@ -4156,7 +4149,7 @@ std::string TypeInfo::toStaticString() const {
     OS << "<generic>";
 
   TITypes TiType = getRawType();
-  
+
 #if 0
   if (hasByRefLocalInfo())
     OS << format("(local %d)", getByRefLocalInfo());


### PR DESCRIPTION
1) Variable renames and spacing fixups in LLILCPal per LLVM convention
2) Spacing fixups remaining in other files by doing a one-time full-run of 
   clang-format (since we now run clang-format only on diffs each commit)
