### PR TITLE
Move to the new CoreCLR PAL EH.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -21,6 +21,7 @@
 #include <cwchar>
 #include <cstring>
 #include <cstdio>
+#include <cassert>
 #include <map>
 
 #include "global.h"


### PR DESCRIPTION
The old SEH emulation has been removed from the CoreCLR PAL in favor of
an implementation based on C++ EH. This updates the LLILC PAL to match.
