### PR TITLE
Add more feature checks to the reader prepass

### DIFF
--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1865,7 +1865,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1984,7 +1984,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2700,7 +2700,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1858,7 +1858,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1977,7 +1977,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2693,7 +2693,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1856,7 +1856,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1975,7 +1975,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2691,7 +2691,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1873,7 +1873,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1992,7 +1992,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2708,7 +2708,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1889,7 +1889,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2008,7 +2008,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2724,7 +2724,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1886,7 +1886,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2005,7 +2005,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2721,7 +2721,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1875,7 +1875,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1994,7 +1994,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2710,7 +2710,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1891,7 +1891,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2010,7 +2010,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2726,7 +2726,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1858,7 +1858,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1977,7 +1977,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2693,7 +2693,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1868,7 +1868,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1987,7 +1987,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2703,7 +2703,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1906,7 +1906,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method CultureInfo::GetFormat using LLILCJit
@@ -2652,7 +2652,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2771,7 +2771,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1872,7 +1872,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1991,7 +1991,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2707,7 +2707,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1858,7 +1858,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1977,7 +1977,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2693,7 +2693,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1856,7 +1856,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1975,7 +1975,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2691,7 +2691,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1873,7 +1873,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1992,7 +1992,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2708,7 +2708,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1889,7 +1889,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2008,7 +2008,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2724,7 +2724,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1886,7 +1886,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2005,7 +2005,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2721,7 +2721,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1875,7 +1875,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1994,7 +1994,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2710,7 +2710,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1917,7 +1917,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2036,7 +2036,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2752,7 +2752,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1921,7 +1921,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2040,7 +2040,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2756,7 +2756,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1917,7 +1917,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2036,7 +2036,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2752,7 +2752,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1856,7 +1856,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1975,7 +1975,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2691,7 +2691,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1873,7 +1873,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1992,7 +1992,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2708,7 +2708,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1858,7 +1858,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1977,7 +1977,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2693,7 +2693,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1858,7 +1858,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1977,7 +1977,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2693,7 +2693,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1868,7 +1868,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1987,7 +1987,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2703,7 +2703,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1856,7 +1856,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1975,7 +1975,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2691,7 +2691,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1884,7 +1884,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2003,7 +2003,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2719,7 +2719,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1869,7 +1869,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1988,7 +1988,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2704,7 +2704,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1866,7 +1866,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1985,7 +1985,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2701,7 +2701,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1872,7 +1872,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1991,7 +1991,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2707,7 +2707,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1903,7 +1903,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2022,7 +2022,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2738,7 +2738,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1966,7 +1966,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method CultureInfo::GetFormat using LLILCJit
@@ -2603,7 +2603,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2722,7 +2722,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1952,7 +1952,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2071,7 +2071,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2787,7 +2787,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -2021,7 +2021,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2140,7 +2140,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2856,7 +2856,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -2443,7 +2443,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2562,7 +2562,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -3278,7 +3278,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1915,7 +1915,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method CultureInfo::GetFormat using LLILCJit
@@ -2552,7 +2552,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -2671,7 +2671,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1854,7 +1854,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1973,7 +1973,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2689,7 +2689,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -193,7 +193,7 @@ Failed to read HashHelpers..cctor[storeStaticField]
 INFO:  jitting method String::UseRandomizedHashing using LLILCJit
 Failed to read String.UseRandomizedHashing[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Object::.ctor using LLILCJit
 Successfully read Object..ctor
 
@@ -250,7 +250,7 @@ Failed to read CultureData.get_Invariant[storeElem]
 INFO:  jitting method CalendarData::.cctor using LLILCJit
 Failed to read CalendarData..cctor[storeElem]
 INFO:  jitting method CalendarData::.ctor using LLILCJit
-Failed to read CalendarData..ctor[Tail call]
+Failed to read CalendarData..ctor[init class]
 INFO:  jitting method CultureData::get_CultureName using LLILCJit
 Successfully read CultureData.get_CultureName
 
@@ -304,7 +304,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -372,7 +372,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[storeStaticField]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -493,7 +493,7 @@ Failed to read CultureInfo.get_UseUserOverride[Tail call]
 INFO:  jitting method CompareInfo::.ctor using LLILCJit
 Failed to read CompareInfo..ctor[Call needs null check]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method CompatibilitySwitches::get_IsCompatibilityBehaviorDefined using LLILCJit
 Successfully read CompatibilitySwitches.get_IsCompatibilityBehaviorDefined
 
@@ -800,7 +800,7 @@ Failed to read PathHelper.NullTerminate[storePrimitiveType]
 INFO:  jitting method PathHelper::GetFullPathName using LLILCJit
 Failed to read PathHelper.GetFullPathName[entryLabel]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method PathHelper::ToString using LLILCJit
 Failed to read PathHelper.ToString[Tail call]
 INFO:  jitting method String::CtorCharPtrStartLength using LLILCJit
@@ -1446,7 +1446,7 @@ Failed to read HashHelpers.ExpandPrime[Tail call]
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
 Failed to read Dictionary`2.Resize[non-const derefAddress]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
 Failed to read AppDomain.CreateAppDomainManager[methodNeedsSecurityCheck]
 INFO:  jitting method AppDomain::get_FusionStore using LLILCJit
@@ -1521,7 +1521,7 @@ Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Failed to read AppDomain.SetupBindingPaths[Tail call]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[genNullCheck]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::GetAppDomainManagerType using LLILCJit
 Failed to read AppDomain.GetAppDomainManagerType[Return refany or value class]
 INFO:  jitting method AppDomain::GetNativeHandle using LLILCJit
@@ -1832,11 +1832,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1854,7 +1854,7 @@ Failed to read Console.EnsureInitialized[Call HasTypeArg]
 INFO:  jitting method Console::<get_Out>b__2 using LLILCJit
 Failed to read Console.<get_Out>b__2[Tail call]
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method ConsolePal::GetStandardFile using LLILCJit
 Successfully read ConsolePal.GetStandardFile
 
@@ -1973,7 +1973,7 @@ entry:
 }
 
 INFO:  jitting method DomainBoundILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainBoundILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method WindowsConsoleStream::.ctor using LLILCJit
 Successfully read WindowsConsoleStream..ctor
 
@@ -2689,7 +2689,7 @@ Failed to read Thread.get_CurrentCulture[Tail call]
 INFO:  jitting method AppDomain::get_Flags using LLILCJit
 Failed to read AppDomain.get_Flags[storeStaticField]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[secretParam]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method Thread::GetCurrentCultureNoAppX using LLILCJit
 Failed to read Thread.GetCurrentCultureNoAppX[Tail call]
 INFO:  jitting method TextWriter::.ctor using LLILCJit


### PR DESCRIPTION
Add up-front checks for features we don't handle yet: synchronized methods, just my code, il stubs with secret parameters, and must-init classes.

Number of handled methods handled is the same but the bail-out explanations are sometimes different. So I've updated the baselines.
