### PR TITLE
Fix a number of warnings generated when building with Clang on Linux.

### DIFF
--- a/include/Pal/LLILCPal.h
+++ b/include/Pal/LLILCPal.h
@@ -482,7 +482,7 @@ void *__cxa_begin_catch(void *exceptionObject) throw();
 void __cxa_end_catch();
 
 #if defined(__cplusplus)
-};
+}
 #endif                               // __cplusplus
 
 typedef LONG EXCEPTION_DISPOSITION;

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1337,7 +1337,7 @@ public:
   CORINFO_CONTEXT_HANDLE getCurrentContext(void);
   uint32_t getCurrentMethodHash(void);
   uint32_t getCurrentMethodAttribs(void);
-  char *getCurrentMethodName(const char **ModuleName);
+  const char *getCurrentMethodName(const char **ModuleName);
   void getCurrentMethodSigData(CorInfoCallConv *Conv, CorInfoType *ReturnType,
                                CORINFO_CLASS_HANDLE *ReturnClass,
                                int32_t *TotalILArgs, bool *IsVarArg,

--- a/include/Reader/readerenum.h
+++ b/include/Reader/readerenum.h
@@ -258,7 +258,7 @@ typedef enum {
   TRY_Xcpt,  // native SEH except
   TRY_CCatch // native C++ catch
 } TryKind;
-};
+}
 
 // Used to map read opcodes to function-specific opcode enumerations.
 // Uses the same ordering as openum.h.

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -123,7 +123,7 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
 
   // Prep main outputs
   *NativeEntry = NULL;
-  *NativeSizeOfCode = NULL;
+  *NativeSizeOfCode = 0;
 
   // Set up state for this thread (if necessary)
   LLILCJitPerThreadState *PerThreadState = State.get();

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -122,14 +122,14 @@ class FlowGraphNodeOffsetList {
   IRNode *ReaderStack;
 
 public:
-  FlowGraphNodeOffsetList *getNext(void) { return Next; }
+  FlowGraphNodeOffsetList *getNext(void) const { return Next; }
   void setNext(FlowGraphNodeOffsetList *N) { Next = N; }
-  FlowGraphNode *getNode(void) { return Node; }
+  FlowGraphNode *getNode(void) const { return Node; }
   void setNode(FlowGraphNode *N) { Node = N; }
-  uint32_t getOffset(void) { return Offset; }
+  uint32_t getOffset(void) const { return Offset; }
   void setOffset(uint32_t O) { Offset = O; }
 
-  IRNode *getStack(void) { return ReaderStack; }
+  IRNode *getStack(void) const { return ReaderStack; }
   void setStack(IRNode *RS) { ReaderStack = RS; }
 };
 
@@ -716,8 +716,8 @@ ReaderBase::getCurrentMethodAttribs(void) {
   return JitInfo->getMethodAttribs(getCurrentMethodHandle());
 }
 
-char *ReaderBase::getCurrentMethodName(const char **ModuleName) {
-  return (char *)JitInfo->getMethodName(getCurrentMethodHandle(), ModuleName);
+const char *ReaderBase::getCurrentMethodName(const char **ModuleName) {
+  return JitInfo->getMethodName(getCurrentMethodHandle(), ModuleName);
 }
 
 mdToken ReaderBase::getMethodDefFromMethod(CORINFO_METHOD_HANDLE Handle) {
@@ -1149,7 +1149,7 @@ void ReaderBase::getMethodSigData(CorInfoCallConv *CallingConvention,
   *TotalILArgs = (uint32_t)Sig.totalILArgs();
   *IsVarArg = Sig.isVarArg();
   *HasThis = Sig.hasThis();
-  *RetSig = NULL;
+  *RetSig = 0;
 }
 
 void ReaderBase::getMethodInfo(CORINFO_METHOD_HANDLE Method,
@@ -2535,8 +2535,8 @@ ReaderBase::fgReplaceBranchTarget(uint32_t Offset,
 int __cdecl labelSortFunction(const void *C1, const void *C2) {
   uint32_t O1, O2;
 
-  O1 = ((FlowGraphNodeOffsetList *)C1)->getOffset();
-  O2 = ((FlowGraphNodeOffsetList *)C2)->getOffset();
+  O1 = ((const FlowGraphNodeOffsetList *)C1)->getOffset();
+  O2 = ((const FlowGraphNodeOffsetList *)C2)->getOffset();
 
   if (O1 < O2)
     return -1;
@@ -7409,7 +7409,7 @@ void ReaderBase::readBytesForFlowGraphNode_Helper(
     case ReaderBaseNS::CEE_LDELEM_R4:
     case ReaderBaseNS::CEE_LDELEM_R8:
     case ReaderBaseNS::CEE_LDELEM_REF:
-      Token = NULL;
+      Token = mdTokenNil;
     LOAD_ELEMENT:
       verifyLoadElem(TheVerificationState, Opcode, &ResolvedToken);
       BREAK_ON_VERIFY_ONLY;
@@ -7844,7 +7844,7 @@ void ReaderBase::readBytesForFlowGraphNode_Helper(
     case ReaderBaseNS::CEE_STELEM_R4:
     case ReaderBaseNS::CEE_STELEM_R8:
     case ReaderBaseNS::CEE_STELEM_REF:
-      Token = NULL;
+      Token = mdTokenNil;
     STORE_ELEMENT:
       verifyStoreElem(TheVerificationState,
                       (ReaderBaseNS::StElemOpcode)MappedValue, &ResolvedToken);
@@ -8927,4 +8927,4 @@ void ReaderBase::resolveToken(mdToken Token, CorInfoTokenKind TokenType,
                               CORINFO_RESOLVED_TOKEN *ResolvedToken) {
   return resolveToken(Token, getCurrentContext(), getCurrentModuleHandle(),
                       TokenType, ResolvedToken);
-};
+}

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -285,10 +285,10 @@ bool rgnGetFinallyEndIsReachable(EHRegion *FinallyRegion) { return false; }
 void rgnSetFinallyEndIsReachable(EHRegion *FinallyRegion, bool IsReachable) {
   return;
 }
-EHRegion *rgnGetFaultTryRegion(EHRegion *FaultRegion) { return NULL; };
+EHRegion *rgnGetFaultTryRegion(EHRegion *FaultRegion) { return NULL; }
 void rgnSetFaultTryRegion(EHRegion *FaultRegion, EHRegion *TryRegion) {
   return;
-};
+}
 EHRegion *rgnGetCatchTryRegion(EHRegion *CatchRegion) { return NULL; }
 void rgnSetCatchTryRegion(EHRegion *CatchRegion, EHRegion *TryRegion) {
   return;
@@ -383,7 +383,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   }
 
   return;
-};
+}
 
 void GenIR::readerMiddlePass() { return; }
 
@@ -727,7 +727,7 @@ void ReaderBase::debugError(const char *Filename, unsigned Linenumber,
   // TODO
   // if (s) JitContext->JitInfo->doAssert(Filename, Linenumber, S);
   // ASSERTNR(UNREACHED);
-};
+}
 
 // Fatal error, reader cannot continue.
 void ReaderBase::fatal(int ErrNum) { LLILCJit::fatal(LLILCJIT_FATAL_ERROR); }
@@ -799,7 +799,7 @@ Type *GenIR::getType(CorInfoType CorType, CORINFO_CLASS_HANDLE ClassHandle,
     CORINFO_CLASS_HANDLE ChildClassHandle = NULL;
     CorInfoType ChildCorType = getChildType(ClassHandle, &ChildClassHandle);
     // LLVM does not allow void*, so use char* instead.
-    if (ChildCorType == ELEMENT_TYPE_VOID) {
+    if (ChildCorType == CORINFO_TYPE_VOID) {
       ASSERT(IsPtr);
       ClassType = getType(CORINFO_TYPE_CHAR, NULL);
     } else if (ChildCorType == CORINFO_TYPE_UNDEF) {
@@ -953,7 +953,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
                              &UTF8Start[UTF8Size], strictConversion);
       if (Result == conversionOK) {
         ASSERT((size_t)(&WideCharBuffer[BufferLength] -
-                        (char16_t *)UTF16Start) == 0);
+                        (const char16_t *)UTF16Start) == 0);
         StructTy->setName((char *)ClassName);
       }
       delete[] ClassName;
@@ -2680,7 +2680,7 @@ IRNode *GenIR::call(ReaderBaseNS::CallOpcode Opcode, mdToken Token,
   }
   IRNode *CallNode;
   return rdrCall(Data, Opcode, &CallNode, NewIR);
-};
+}
 
 bool isNonVolatileWriteHelperCall(CorInfoHelpFunc HelperId) {
   switch (HelperId) {
@@ -2805,7 +2805,7 @@ IRNode *GenIR::makeDirectCallTargetNode(CORINFO_METHOD_HANDLE Method,
 
   return (IRNode *)LLVMBuilder->CreateIntToPtr(
       CodeAddrValue, getUnmanagedPointerType(FunctionType));
-};
+}
 
 IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
                        CallArgTriple *ArgArray, uint32_t NumArgs,
@@ -3430,7 +3430,7 @@ IRNode *GenIR::loadStr(mdToken Token, IRNode **NewIR) {
   ASSERTNR(StringHandle != NULL);
 
   return stringLiteral(Token, StringHandle, Iat, NewIR);
-};
+}
 
 IRNode *GenIR::stringLiteral(mdToken Token, void *StringHandle,
                              InfoAccessType Iat, IRNode **NewIR) {


### PR DESCRIPTION
Most of these were self-assignment, poorly type comparisons, or casting
away const.
