### PR TITLE
Redirect Build and Test Artifacts to stdout

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -765,7 +765,7 @@ function Global:RunTest([string]$Arch="x64", [string]$Build="Release")
   pushd .
   cd $CoreCLRTestAssets\coreclr\tests
 
-  .\runtest $Arch $Build EnableAltJit LLILCJit $CoreCLRRuntime\$CoreCLRVersion\bin 
+  .\runtest $Arch $Build EnableAltJit LLILCJit $CoreCLRRuntime\$CoreCLRVersion\bin | Write-Host
   CheckDiff -Create $True -UseDiffTool $False -Arch $Arch -Build $Build
   $NumFailures = CheckFailure -Arch $Arch -Build $Build
   popd


### PR DESCRIPTION
The user needs to be able to see the output of BuildLLVM, Build, and RunTests. In the lab, the return value of RunTests is captured, so we need to pipe the output of runtest to Host so the user can see the output (and what the actual failures are). With the two build functions, the output of running msbuild were being saved in a variable, but never output. Again, if there are any failures, the user needs to be able to see them, so we do not want to save the output to a variable, we want them to be output to std out.
