### PR TITLE
Ignore files created by CMake when building and running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ publish/
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
 #packages/
 
+# CMake generated files
+CMakeFiles/
+
 # Windows Azure Build Output
 csx
 *.build.csdef


### PR DESCRIPTION
Some part of the test build or run invokes CMake, which creates some temporary files within the LLILC repo. Ignore these.
