### PR TITLE
Change CoreCLR URL

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -417,7 +417,7 @@ function Global:GetCLRTestAssets
     pushd .
     New-Item $CoreCLRTestAssets -itemtype Directory  | Out-Null
     cd $CoreCLRTestAssets
-    git clone https://github.com/dotnet/coreclr.git
+    git clone git://github.com/dotnet/coreclr.git
     popd
   }
   else {


### PR DESCRIPTION
Change to a different CoreCLR URL to prohibit push from the automatically created CoreCLR repo. This is to avoid that developer by mistake makes change in the automatically created CoreCLR repo in CoreCLRTestAssets and push it to dotnet\CoreCLR.
