### PR TITLE
Update RunTests to report failures and diffs

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -314,10 +314,10 @@ function SetVCVars
         # Ignore: Setting the prompt environment variable has no
         #         connection to the PowerShell prompt
       } elseif ($N -eq "title") {
-        $host.ui.rawui.windowtitle = $matches[2];
-        Set-Item -Path "env:$N" -Value $matches[2];
+        $host.ui.rawui.windowtitle = $matches[2]
+        Set-Item -Path "env:$N" -Value $matches[2]
       } else {
-        Set-Item -Path "env:$N" -Value $matches[2];
+        Set-Item -Path "env:$N" -Value $matches[2]
       }
     }
     elseif (!$FoundStartFlag) {
@@ -827,8 +827,8 @@ function Global:CheckDiff([bool]$Create = $false, [bool]$UseDiffTool = $True, [s
     New-Item -itemtype directory $LLILCTestResult\Diff\Base | Out-Null
     New-Item -itemtype directory $LLILCTestResult\Diff\Run | Out-Null
 
-    $TotalCount = 0;
-    $DiffCount = 0;
+    $TotalCount = 0
+    $DiffCount = 0
     Get-ChildItem -recurse -path $CoreCLRTestTargetBinaries\Reports | Where {$_.FullName -match "error.txt"} | `
     Foreach-Object {
       $TotalCount = $TotalCount + 1


### PR DESCRIPTION
We want RunTests to return true if there are no diffs and no failures or false if there are diffs or failures.  This change also fixes the path to the test results log and changes Write-Output to Write-Host in CheckDiffs so that we do not pollute the return value.
