### PR TITLE
Remove volatility check in call helper

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -460,9 +460,8 @@ public:
                           IRNode **NewIR) override {
     throw NotYetImplementedException("interlockedCmpXchg");
   };
-  bool memoryBarrier(IRNode **NewIR) override {
-    throw NotYetImplementedException("memoryBarrier");
-  };
+  bool memoryBarrier(IRNode **NewIR) override;
+
   void switchOpcode(IRNode *Opr, IRNode **NewIR) override;
 
   void throwOpcode(IRNode *Arg1, IRNode **NewIR) override;

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3719,7 +3832,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3712,7 +3825,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3710,7 +3823,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3727,7 +3840,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3743,7 +3856,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3740,7 +3853,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3729,7 +3842,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3745,7 +3858,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3712,7 +3825,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3722,7 +3835,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -4532,7 +4645,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3726,7 +3839,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3712,7 +3825,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3710,7 +3823,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3727,7 +3840,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3743,7 +3856,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3740,7 +3853,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3729,7 +3842,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3771,7 +3884,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3775,7 +3888,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3771,7 +3884,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3710,7 +3823,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3727,7 +3840,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3712,7 +3825,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3712,7 +3825,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3722,7 +3835,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3710,7 +3823,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3738,7 +3851,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3723,7 +3836,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3720,7 +3833,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3726,7 +3839,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3757,7 +3870,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -4483,7 +4596,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3806,7 +3919,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3875,7 +3988,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -4297,7 +4410,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -4432,7 +4545,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3708,7 +3821,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -803,7 +803,59 @@ entry:
 }
 
 INFO:  jitting method CultureInfo::Init using LLILCJit
-Failed to read CultureInfo.Init[Helper performs volatile operation]
+Successfully read CultureInfo.Init
+
+define i8 @CultureInfo.Init() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1720
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %3, null
+  br i1 %4, label %13, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = load %System.String addrspace(1)** inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)**), align 8
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.CultureInfo addrspace(1)*, %System.String addrspace(1)*, i8)*)(%System.Globalization.CultureInfo addrspace(1)* %7, %System.String addrspace(1)* %6, i8 0)
+  store %System.Globalization.CultureInfo addrspace(1)* %7, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %8 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %9 = getelementptr inbounds %System.Globalization.CultureInfo addrspace(1)* %8, i32 0, i32 11
+  store i8 1, i8 addrspace(1)* %9
+  %10 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 1720
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %12, %System.Globalization.CultureInfo addrspace(1)* %10)
+  fence seq_cst
+  br label %13
+
+; <label>:13                                      ; preds = %entry, %5
+  %14 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %15 = getelementptr inbounds i8 addrspace(1)* %14, i64 1720
+  %16 = addrspacecast i8 addrspace(1)* %15 to %System.Globalization.CultureInfo addrspace(1)**
+  %17 = load volatile %System.Globalization.CultureInfo addrspace(1)** %16
+  %18 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %19 = getelementptr inbounds i8 addrspace(1)* %18, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %19, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %20 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %21 = getelementptr inbounds i8 addrspace(1)* %20, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %21, %System.Globalization.CultureInfo addrspace(1)* %17)
+  fence seq_cst
+  %22 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %23 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %24 = getelementptr inbounds i8 addrspace(1)* %23, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %24, %System.Globalization.CultureInfo addrspace(1)* %22)
+  fence seq_cst
+  %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %26 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %27 = getelementptr inbounds i8 addrspace(1)* %26, i64 1728
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %27, %System.Globalization.CultureInfo addrspace(1)* %25)
+  fence seq_cst
+  ret i8 1
+}
+
 INFO:  jitting method CultureInfo::.ctor using LLILCJit
 Failed to read CultureInfo..ctor[Call intrinsic]
 INFO:  jitting method CultureData::GetCultureData using LLILCJit
@@ -1002,7 +1054,40 @@ Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
-Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
+Successfully read CultureInfo.get_UserDefaultCulture
+
+define %System.Globalization.CultureInfo addrspace(1)* @CultureInfo.get_UserDefaultCulture() {
+entry:
+  %loc0 = alloca %System.Globalization.CultureInfo addrspace(1)*
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 1712
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.CultureInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.CultureInfo addrspace(1)** %2
+  store %System.Globalization.CultureInfo addrspace(1)* %3, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %4 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %5 = icmp ne %System.Globalization.CultureInfo addrspace(1)* %4, null
+  br i1 %5, label %14, label %6
+
+; <label>:6                                       ; preds = %entry
+  %7 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.CultureInfo addrspace(1)* %7)
+  fence seq_cst
+  %10 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
+  store %System.Globalization.CultureInfo addrspace(1)* %10, %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %11 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  %12 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 979)
+  %13 = getelementptr inbounds i8 addrspace(1)* %12, i64 1712
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)*)*)(i8 addrspace(1)* %13, %System.Globalization.CultureInfo addrspace(1)* %11)
+  fence seq_cst
+  br label %14
+
+; <label>:14                                      ; preds = %entry, %6
+  %15 = load %System.Globalization.CultureInfo addrspace(1)** %loc0
+  ret %System.Globalization.CultureInfo addrspace(1)* %15
+}
+
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
 Successfully read CultureInfo.get_Name
 
@@ -2809,7 +2894,35 @@ Failed to read Enumerator.get_Current[loadNonPrimitiveObj]
 INFO:  jitting method OrdinalComparer::GetHashCode using LLILCJit
 Failed to read OrdinalComparer.GetHashCode[Tail call]
 INFO:  jitting method TextInfo::get_Invariant using LLILCJit
-Failed to read TextInfo.get_Invariant[Helper performs volatile operation]
+Successfully read TextInfo.get_Invariant
+
+define %System.Globalization.TextInfo addrspace(1)* @TextInfo.get_Invariant() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2032
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Globalization.TextInfo addrspace(1)**
+  %3 = load volatile %System.Globalization.TextInfo addrspace(1)** %2
+  %4 = icmp ne %System.Globalization.TextInfo addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Globalization.CultureData addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureData addrspace(1)* ()*)()
+  %7 = call %System.Globalization.TextInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.TextInfo addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Globalization.TextInfo addrspace(1)*, %System.Globalization.CultureData addrspace(1)*)*)(%System.Globalization.TextInfo addrspace(1)* %7, %System.Globalization.CultureData addrspace(1)* %6)
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2032
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Globalization.TextInfo addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Globalization.TextInfo addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1012)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2032
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Globalization.TextInfo addrspace(1)**
+  %14 = load volatile %System.Globalization.TextInfo addrspace(1)** %13
+  ret %System.Globalization.TextInfo addrspace(1)* %14
+}
+
 INFO:  jitting method TextInfo::.ctor using LLILCJit
 Successfully read TextInfo..ctor
 
@@ -3708,7 +3821,37 @@ entry:
 }
 
 INFO:  jitting method Encoding::get_UTF8 using LLILCJit
-Failed to read Encoding.get_UTF8[Helper performs volatile operation]
+Successfully read Encoding.get_UTF8
+
+define %System.Text.Encoding addrspace(1)* @Encoding.get_UTF8() {
+entry:
+  %0 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %1 = getelementptr inbounds i8 addrspace(1)* %0, i64 2272
+  %2 = addrspacecast i8 addrspace(1)* %1 to %System.Text.Encoding addrspace(1)**
+  %3 = load volatile %System.Text.Encoding addrspace(1)** %2
+  %4 = icmp ne %System.Text.Encoding addrspace(1)* %3, null
+  br i1 %4, label %10, label %5
+
+; <label>:5                                       ; preds = %entry
+  %6 = call %System.Text.UTF8Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.UTF8Encoding addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.UTF8Encoding addrspace(1)*, i8)*)(%System.Text.UTF8Encoding addrspace(1)* %6, i8 1)
+  %7 = bitcast %System.Text.UTF8Encoding addrspace(1)* %6 to %System.Text.Encoding addrspace(1)*
+  %8 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %9 = getelementptr inbounds i8 addrspace(1)* %8, i64 2272
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void (i8 addrspace(1)*, %System.Text.Encoding addrspace(1)*)*)(i8 addrspace(1)* %9, %System.Text.Encoding addrspace(1)* %7)
+  fence seq_cst
+  br label %10
+
+; <label>:10                                      ; preds = %entry, %5
+  %11 = call i8 addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to i8 addrspace(1)* (i64, i64)*)(i64 NORMALIZED_ADDRESS, i64 1030)
+  %12 = getelementptr inbounds i8 addrspace(1)* %11, i64 2272
+  %13 = addrspacecast i8 addrspace(1)* %12 to %System.Text.Encoding addrspace(1)**
+  %14 = load volatile %System.Text.Encoding addrspace(1)** %13
+  ret %System.Text.Encoding addrspace(1)* %14
+}
+
+INFO:  jitting method UTF8Encoding::.ctor using LLILCJit
+Failed to read UTF8Encoding..ctor[Tail call]
 INFO:  jitting method UTF8Encoding::SetDefaultFallbacks using LLILCJit
 Successfully read UTF8Encoding.SetDefaultFallbacks
 


### PR DESCRIPTION
We unnecessarily check volatility in call helper where we always emit call instead of intrinsic for certain cases.
I removed it and added comments below when we are about to use intrinsic.
