### PR TITLE
Throw NotYetImplemented for struct parameters

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -380,6 +380,12 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   int32_t I;
   for (CurrentArg = Args++, I = 0; CurrentArg != Function->arg_end();
        CurrentArg = Args++, I++) {
+    if (CurrentArg->getType()->isStructTy()) {
+      // LLVM doesn't use the same calling convention as other .Net jits
+      // for structs, and we want to be able to select jits per-method
+      // so we need them to interoperate.
+      throw NotYetImplementedException("Struct parameter");
+    }
     LLVMBuilder->CreateStore(CurrentArg, Arguments[I]);
   }
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
@@ -1967,5 +1967,5 @@ Failed to read PermissionSet..ctor[Tail call]
 INFO:  jitting method BringUpTest::Main using LLILCJit
 Failed to read BringUpTest.Main[AddressOfValue]
 INFO:  jitting method BringUpTest::StructFldAddr using LLILCJit
-Failed to read BringUpTest.StructFldAddr[genNullCheck]
+Failed to read BringUpTest.StructFldAddr[Struct parameter]
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -349,7 +349,7 @@ Failed to read CultureInfo.InitUserDefaultCulture[Tail call]
 INFO:  jitting method CultureInfo::GetDefaultLocaleName using LLILCJit
 Failed to read CultureInfo.GetDefaultLocaleName[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::GetCultureByName using LLILCJit
 Successfully read CultureInfo.GetCultureByName
 
@@ -417,7 +417,7 @@ Failed to read CultureInfo.InitUserDefaultUICulture[Tail call]
 INFO:  jitting method CultureInfo::GetUserDefaultUILanguage using LLILCJit
 Failed to read CultureInfo.GetUserDefaultUILanguage[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method CultureInfo::get_UserDefaultCulture using LLILCJit
 Failed to read CultureInfo.get_UserDefaultCulture[Helper performs volatile operation]
 INFO:  jitting method CultureInfo::get_Name using LLILCJit
@@ -1955,11 +1955,11 @@ entry:
 }
 
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::SetupDomainSecurity using LLILCJit
 Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
-Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
+Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
 Failed to read AppDomain.RunInitializer[Call needs null check]
 INFO:  jitting method PermissionSet::.ctor using LLILCJit


### PR DESCRIPTION
We already had an exclusion for call struct arguments; this adds one for function struct parameters.  The linkage we're getting from LLVM for struct parameters doesn't agree with what the production jit generates for struct arguments, so interop is broken if we let these through.

In the bring-up tests, this makes four functions in all tests fail up-front instead of failing at "publish secret param".  This also makes the StructFldAddr test's primary method fail up-front instead of at genNullCheck.  My PR #183 needs this change else the interop failure makes that test fail at run-time once genNullCheck is implemented.
