### PR TITLE
Two small fixes to {,lib/Jit/}CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   set(WITH_LLVM "" CACHE PATH "Path to the directory where LLVM was built or installed.")
 
   # Probe for LLVM. First with CMake (unless the user has specified an LLVM install), then manually.
-  if( NOT WITH_LLVM STREQUAL "" )
+  if( WITH_LLVM STREQUAL "" )
     find_package(LLVM QUIET CONFIG)
   endif()
 

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -58,6 +58,6 @@ add_dependencies(llilcjit LLILCReader)
 
 target_link_libraries(
   llilcjit
-  ${cmake_2_8_12_PRIVATE}
+  PRIVATE
   ${LLILCJIT_LINK_LIBRARIES}
   )


### PR DESCRIPTION
- LLVM recently bumped the required version of CMake to 2.8.12.2, which
  contains proper support for private linkage in link_target_library.
  This commit removes the workaround that had previously been in place.
- LLVM probing was slightly off for out-of-tree builds.
